### PR TITLE
confederations + nationalities

### DIFF
--- a/ofm/core/db/database.py
+++ b/ofm/core/db/database.py
@@ -53,6 +53,14 @@ class DB:
     def clubs_def_file(self) -> str:
         return self.settings.clubs_def
 
+    @property
+    def fifa_codes_file(self) -> str:
+        return self.settings.fifa_codes
+
+    @property
+    def fifa_conf_file(self) -> str:
+        return self.settings.fifa_conf
+
     def load_clubs(self) -> list[dict]:
         with open(self.clubs_file, "r") as fp:
             return json.load(fp)
@@ -63,6 +71,14 @@ class DB:
 
     def load_club_definitions(self) -> list[dict]:
         with open(self.clubs_def_file, "r") as fp:
+            return json.load(fp)
+
+    def load_fifa_codes(self) -> dict:
+        with open(self.fifa_codes_file, "r") as fp:
+            return json.load(fp)
+
+    def load_fifa_conf(self) -> list[dict]:
+        with open(self.fifa_conf_file, "r") as fp:
             return json.load(fp)
 
     def load_squads_file(self) -> list[dict]:
@@ -148,7 +164,9 @@ class DB:
         if clubs_def is None:
             clubs_def = self.load_club_definitions()
 
-        team_gen = TeamGenerator(clubs_def, season_start)
+        fifa_conf = self.load_fifa_conf()
+
+        team_gen = TeamGenerator(clubs_def, fifa_conf, season_start)
         clubs = team_gen.generate()
         clubs_dict = [club.serialize() for club in clubs]
 

--- a/ofm/core/settings.py
+++ b/ofm/core/settings.py
@@ -26,13 +26,15 @@ class Settings:
         self,
         root_dir: Union[str, Path] = PROJECT_DIR,
         settings: Union[str, Path] = os.path.join(PROJECT_DIR, "settings.yaml"),
-    ):
+    ) -> None:
         self.root_dir = root_dir
         self.res: str = os.path.join(root_dir, "res")
         self.images: str = os.path.join(root_dir, "images")
         self.db: str = os.path.join(self.res, "db")
         self.save: str = os.path.join(root_dir, "save")
         self.clubs_def: str = os.path.join(self.res, "clubs_def.json")
+        self.fifa_codes: str = os.path.join(self.res, "fifa-country-codes.json")
+        self.fifa_conf: str = os.path.join(self.res, "fifa-confederations.json")
         self.squads_def: str = os.path.join(self.res, "squads_def.json")
         self.squads_file: str = os.path.join(self.db, "squads.json")
         self.players_file: str = os.path.join(self.db, "players.json")
@@ -46,6 +48,8 @@ class Settings:
             "db": self.db,
             "save": self.save,
             "clubs_def": self.clubs_def,
+            "fifa_codes": self.fifa_codes,
+            "fifa_conf": self.fifa_conf,
             "squads": self.squads_file,
             "players": self.players_file,
             "clubs": self.clubs_file,
@@ -57,6 +61,8 @@ class Settings:
         self.db = data["db"]
         self.save = data["save"]
         self.clubs_def = data["clubs_def"]
+        self.fifa_codes = data["fifa_codes"]
+        self.fifa_conf = data["fifa_conf"]
         self.squads_file = data["squads"]
         self.players_file = data["players"]
         self.clubs_file = data["clubs"]

--- a/ofm/res/clubs_def.json
+++ b/ofm/res/clubs_def.json
@@ -1,25253 +1,9559 @@
 [
   {
     "name": "KS Teuta",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Durr\\u00ebs",
     "stadium": "Niko Dovana",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.86
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.07
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.07
-        }
-      ],
       "mu": 83,
       "sigma": 20
     }
   },
   {
     "name": "KS Elbasani",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Elbasan",
     "stadium": "Elbasan Arena",
     "stadium_capacity": 12800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.72
-        },
-        {
-          "name": "Angola",
-          "probability": 0.28
-        }
-      ],
       "mu": 77,
       "sigma": 23
     }
   },
   {
     "name": "KS Bylis Ballsh",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Ballsh",
     "stadium": "Agush Maca",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.81
-        },
-        {
-          "name": "Togo",
-          "probability": 0.19
-        }
-      ],
       "mu": 64,
       "sigma": 30
     }
   },
   {
     "name": "KF T\\u00ebrbuni Puk\\u00eb",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Puk\\u00eb",
     "stadium": "Ismail Xhemali Stadium",
     "stadium_capacity": 1950,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.71
-        },
-        {
-          "name": "Russia",
-          "probability": 0.15
-        },
-        {
-          "name": "Germany",
-          "probability": 0.15
-        }
-      ],
       "mu": 47,
       "sigma": 18
     }
   },
   {
     "name": "FC Kamza",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Kam\\u00ebz",
     "stadium": "Kam\\u00ebz Stadium",
     "stadium_capacity": 4800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.89
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.02
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.02
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.02
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.02
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 28
     }
   },
   {
     "name": "KF Turbina C\\u00ebrrik",
-    "country": "Albania",
+    "country": "ALB",
     "location": "C\\u00ebrrik",
     "stadium": "Nexhip Trungu Stadium",
     "stadium_capacity": 6600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.84
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.04
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        }
-      ],
       "mu": 72,
       "sigma": 6
     }
   },
   {
     "name": "Beselidhja Lezhe",
-    "country": "Albania",
+    "country": "ALB",
     "location": "Lezh\\u00eb",
     "stadium": "Brian Filipi Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Albania",
-          "probability": 0.85
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.08
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.08
-        }
-      ],
       "mu": 69,
       "sigma": 25
     }
   },
   {
     "name": "ES S\\u00e9tif",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "S\\u00e9tif",
     "stadium": "Stade 8 Mai 1945",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.9
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.02
-        },
-        {
-          "name": "Chile",
-          "probability": 0.02
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.02
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        }
-      ],
       "mu": 64,
       "sigma": 29
     }
   },
   {
     "name": "USM Alger",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Algiers",
     "stadium": "Omar Hammadi",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.78
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.05
-        },
-        {
-          "name": "Japan",
-          "probability": 0.05
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.05
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 31
     }
   },
   {
     "name": "USM El Harrach",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Algiers",
     "stadium": "1er Novembre 1954",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.84
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        },
-        {
-          "name": "France",
-          "probability": 0.03
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.03
-        }
-      ],
       "mu": 85,
       "sigma": 34
     }
   },
   {
     "name": "CR Belouizdad",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Mohamed Belouizdad",
     "stadium": "Stade 20 Ao\\u00fbt 1955",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.76
-        },
-        {
-          "name": "Greece",
-          "probability": 0.24
-        }
-      ],
       "mu": 45,
       "sigma": 23
     }
   },
   {
     "name": "JS Saoura",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "M\\u00e9ridja",
     "stadium": "20 Ao\\u00fbt 1955 B\\u00e9char",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.73
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.27
-        }
-      ],
       "mu": 65,
       "sigma": 26
     }
   },
   {
     "name": "WA Tlemcen",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Tlemcen",
     "stadium": "Akid Lotfi",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.89
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.11
-        }
-      ],
       "mu": 49,
       "sigma": 6
     }
   },
   {
     "name": "NA Hussein Dey",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Hussein Dey",
     "stadium": "Stade 20 Ao\\u00fbt 1955",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.79
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.1
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.1
-        }
-      ],
       "mu": 82,
       "sigma": 35
     }
   },
   {
     "name": "RC Relizane",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "R\\u00e9lizane",
     "stadium": "Stade Tahar Zoughari",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.81
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 29
     }
   },
   {
     "name": "Paradou AC",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Algiers",
     "stadium": "Omar Hammadi",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.8
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 33
     }
   },
   {
     "name": "HB Chelghoum La\\u00efd",
-    "country": "Algeria",
+    "country": "ALG",
     "location": "Chelghoum La\\u00efd",
     "stadium": "December 11, 1961 Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Algeria",
-          "probability": 0.88
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 28
     }
   },
   {
     "name": "UE Sant Juli\\u00e0",
-    "country": "Andorra",
+    "country": "AND",
     "location": "Sant Julia de Loria",
     "stadium": "DEVK-Arena",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Andorra",
-          "probability": 0.84
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.08
-        },
-        {
-          "name": "Canada",
-          "probability": 0.08
-        }
-      ],
       "mu": 58,
       "sigma": 34
     }
   },
   {
     "name": "FC Encamp",
-    "country": "Andorra",
+    "country": "AND",
     "location": "Encamp",
     "stadium": "Camp de Futbol d'Encamp",
     "stadium_capacity": 550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Andorra",
-          "probability": 0.81
-        },
-        {
-          "name": "Iran",
-          "probability": 0.19
-        }
-      ],
       "mu": 46,
       "sigma": 26
     }
   },
   {
     "name": "Recreativo do Libolo",
-    "country": "Angola",
+    "country": "ANG",
     "location": "Calulo",
     "stadium": "Calulo",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Angola",
-          "probability": 0.71
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.06
-        },
-        {
-          "name": "Australia",
-          "probability": 0.06
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        }
-      ],
       "mu": 52,
       "sigma": 11
     }
   },
   {
     "name": "Antigua Barracuda",
-    "country": "Antigua and Barbuda",
+    "country": "ATG",
     "location": "Saint Georges",
     "stadium": "Stanford Cricket Ground",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.79
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        }
-      ],
       "mu": 69,
       "sigma": 20
     }
   },
   {
     "name": "Estudiantes de LP",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "La Plata",
     "stadium": "Jorge Luis Hirschi",
     "stadium_capacity": 30018,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.73
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.09
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.09
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.09
-        }
-      ],
       "mu": 59,
       "sigma": 25
     }
   },
   {
     "name": "Gimnasia de Jujuy",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "San Salvador de Jujuy",
     "stadium": "23 de Agosto",
     "stadium_capacity": 23000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.9
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.1
-        }
-      ],
       "mu": 69,
       "sigma": 32
     }
   },
   {
     "name": "Uni\\u00f3n Santa Fe",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Santa Fe",
     "stadium": "15 de Abril",
     "stadium_capacity": 23000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.74
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.13
-        },
-        {
-          "name": "Canada",
-          "probability": 0.13
-        }
-      ],
       "mu": 73,
       "sigma": 23
     }
   },
   {
     "name": "Atl\\u00e9tico Tucum\\u00e1n",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Tucum\\u00e1n",
     "stadium": "Monumental Jose Fierro",
     "stadium_capacity": 32700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.81
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.05
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 12
     }
   },
   {
     "name": "CA Aldosivi",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Mar del Plata",
     "stadium": "Jos\\u00e9 Mar\\u00eda Minella",
     "stadium_capacity": 35354,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.88
-        },
-        {
-          "name": "Panama",
-          "probability": 0.02
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.02
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.02
-        },
-        {
-          "name": "Finland",
-          "probability": 0.02
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.02
-        }
-      ],
       "mu": 80,
       "sigma": 23
     }
   },
   {
     "name": "CA Atlanta",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Buenos Aires",
     "stadium": "Don Le\\u00f3n Kolbovsky",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.9
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.03
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        }
-      ],
       "mu": 46,
       "sigma": 31
     }
   },
   {
     "name": "Central C\\u00f3rdoba de Rosario",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Rosario",
     "stadium": "Gabino Sosa",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.83
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Italy",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        }
-      ],
       "mu": 48,
       "sigma": 26
     }
   },
   {
     "name": "CA Estudiantes BA",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Caseros, Buenos Aires",
     "stadium": "Ciudad de Caseros",
     "stadium_capacity": 16740,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.88
-        },
-        {
-          "name": "Norway",
-          "probability": 0.12
-        }
-      ],
       "mu": 46,
       "sigma": 26
     }
   },
   {
     "name": "CA Temperley",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Lomas de Zamora",
     "stadium": "Alfredo Beranger Temperley",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.82
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.06
-        }
-      ],
       "mu": 65,
       "sigma": 25
     }
   },
   {
     "name": "Villa San Carlos",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Berisso",
     "stadium": "Genacio S\\u00e1lice",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.78
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.05
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Malta",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        }
-      ],
       "mu": 73,
       "sigma": 34
     }
   },
   {
     "name": "Club F\\u00e9nix",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Buenos Aires",
     "stadium": "Carlos Barraza",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.72
-        },
-        {
-          "name": "Chile",
-          "probability": 0.09
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.09
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.09
-        }
-      ],
       "mu": 56,
       "sigma": 22
     }
   },
   {
     "name": "Deportivo Laferrere",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "La Matanza Partido",
     "stadium": "Jos\\u00e9 Luis S\\u00e1nchez",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.86
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.14
-        }
-      ],
       "mu": 68,
       "sigma": 5
     }
   },
   {
     "name": "Club Rivadavia",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Lincoln",
     "stadium": "El Coliseo",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.74
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.26
-        }
-      ],
       "mu": 63,
       "sigma": 18
     }
   },
   {
     "name": "Guaran\\u00ed Antonio Franco",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Posadas",
     "stadium": "Clemente de Oliviera",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.83
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.06
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.06
-        }
-      ],
       "mu": 68,
       "sigma": 25
     }
   },
   {
     "name": "Central Norte",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Salta",
     "stadium": "Dr. Luis G\\u00fcemes",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.82
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.04
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        }
-      ],
       "mu": 62,
       "sigma": 8
     }
   },
   {
     "name": "Estudiantes de R\\u00edo Cuarto",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "R\\u00edo Cuarto",
     "stadium": "R\\u00edo Cuarto",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.87
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 33
     }
   },
   {
     "name": "Juventud Antoniana",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Salta",
     "stadium": "Estadio Padre Ernesto Martearena",
     "stadium_capacity": 20408,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.9
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.03
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 13
     }
   },
   {
     "name": "Sarmiento de Leones",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Leones",
     "stadium": "La Calderita",
     "stadium_capacity": 3200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.78
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.22
-        }
-      ],
       "mu": 45,
       "sigma": 21
     }
   },
   {
     "name": "Gimnasia y Tiro",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Salta",
     "stadium": "El Gigante del Norte",
     "stadium_capacity": 24300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.77
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.11
-        },
-        {
-          "name": "England",
-          "probability": 0.11
-        }
-      ],
       "mu": 49,
       "sigma": 7
     }
   },
   {
     "name": "Sportivo Patria",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Formosa",
     "stadium": "Estadio Antonio Romero",
     "stadium_capacity": 33000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.81
-        },
-        {
-          "name": "India",
-          "probability": 0.19
-        }
-      ],
       "mu": 83,
       "sigma": 29
     }
   },
   {
     "name": "Racing de Olavarr\\u00eda",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Olavarr\\u00eda",
     "stadium": "Jos\\u00e9 Buglione Martinese",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.75
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 31
     }
   },
   {
     "name": "Uni\\u00f3n Aconquija",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Aconquija",
     "stadium": "Estadio Municipal de Aconquija",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.75
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.05
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.05
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 32
     }
   },
   {
     "name": "Cruz del Sur",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Bariloche",
     "stadium": "Municipal Bariloche",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.79
-        },
-        {
-          "name": "England",
-          "probability": 0.21
-        }
-      ],
       "mu": 47,
       "sigma": 29
     }
   },
   {
     "name": "Gimnasia de Mendoza",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Mendoza",
     "stadium": "V\\u00edctor Legrotaglie",
     "stadium_capacity": 11500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.75
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.06
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.06
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.06
-        }
-      ],
       "mu": 63,
       "sigma": 26
     }
   },
   {
     "name": "Jorge Newbery",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Villa Mercedes",
     "stadium": "Osvaldo Centioni",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.76
-        },
-        {
-          "name": "Panama",
-          "probability": 0.24
-        }
-      ],
       "mu": 62,
       "sigma": 34
     }
   },
   {
     "name": "Sportivo Las Parejas",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Las Parejas",
     "stadium": "Estadio La Perrera",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.71
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.1
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.1
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.1
-        }
-      ],
       "mu": 63,
       "sigma": 35
     }
   },
   {
     "name": "Tiro Federal BB",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Bah\\u00eda Blanca",
     "stadium": "Estadio Onofre Pirrone",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.86
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Norway",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 22
     }
   },
   {
     "name": "Atl\\u00e9tico Camioneros",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Buenos Aires",
     "stadium": "Estadio Carlos V",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.81
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        },
-        {
-          "name": "Spain",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 16
     }
   },
   {
     "name": "CA San Miguel",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "San Miguel",
     "stadium": "Los Polvorines",
     "stadium_capacity": 6800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.71
-        },
-        {
-          "name": "Togo",
-          "probability": 0.07
-        },
-        {
-          "name": "Angola",
-          "probability": 0.07
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        },
-        {
-          "name": "Japan",
-          "probability": 0.07
-        }
-      ],
       "mu": 55,
       "sigma": 23
     }
   },
   {
     "name": "CA Pac\\u00edfico",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Bah\\u00eda Blanca",
     "stadium": "Adolfo Osvaldo PIrola",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.85
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        },
-        {
-          "name": "Iran",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 9
     }
   },
   {
     "name": "Concepci\\u00f3n FC",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Concepci\\u00f3n",
     "stadium": "Estadio Stewart Shipton",
     "stadium_capacity": 12550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.76
-        },
-        {
-          "name": "Canada",
-          "probability": 0.06
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.06
-        },
-        {
-          "name": "Chile",
-          "probability": 0.06
-        },
-        {
-          "name": "Finland",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 21
     }
   },
   {
     "name": "Talleres de RE",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Remedios de Escalada",
     "stadium": "Estadio de Talleres",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.75
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.06
-        },
-        {
-          "name": "Spain",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.06
-        }
-      ],
       "mu": 58,
       "sigma": 12
     }
   },
   {
     "name": "Belgrano de Paran\\u00e1",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Paran\\u00e1",
     "stadium": "Nuevo Estadio Mondonguero",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.83
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        }
-      ],
       "mu": 85,
       "sigma": 9
     }
   },
   {
     "name": "CA Alvarado",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Mar del Plata",
     "stadium": "Jos\\u00e9 Mar\\u00eda Minella",
     "stadium_capacity": 35354,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.78
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.04
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 16
     }
   },
   {
     "name": "Sacachispas FC",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Buenos Aires",
     "stadium": "Beto Larossa",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.78
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.05
-        },
-        {
-          "name": "Poland",
-          "probability": 0.05
-        }
-      ],
       "mu": 83,
       "sigma": 14
     }
   },
   {
     "name": "Club El Porvenir",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Gerli",
     "stadium": "Estadio Gildo Francisco Ghersinich",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.74
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.09
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.09
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.09
-        }
-      ],
       "mu": 46,
       "sigma": 27
     }
   },
   {
     "name": "CA Germinal",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Rawson",
     "stadium": "El Fort\\u00edn",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.78
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 27
     }
   },
   {
     "name": "AD Berazategui",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Berazategui",
     "stadium": "Estadio Norman Lee",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.77
-        },
-        {
-          "name": "Wales",
-          "probability": 0.08
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.08
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.08
-        }
-      ],
       "mu": 71,
       "sigma": 13
     }
   },
   {
     "name": "San Mart\\u00edn de Formosa",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Ciudad de Formosa",
     "stadium": "17 De Octubre",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.83
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.06
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.06
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 34
     }
   },
   {
     "name": "Defensores Unidos",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Buenos Aires",
     "stadium": "Estadio Gigante de Villa Fox",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.83
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.09
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.09
-        }
-      ],
       "mu": 85,
       "sigma": 10
     }
   },
   {
     "name": "Ciudad de Bol\\u00edvar",
-    "country": "Argentina",
+    "country": "ARG",
     "location": "Bol\\u00edvar",
     "stadium": "Estadio Municipal Eva Per\\u00f3n",
     "stadium_capacity": 3300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Argentina",
-          "probability": 0.71
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.29
-        }
-      ],
       "mu": 67,
       "sigma": 19
     }
   },
   {
     "name": "FC Yerevan",
-    "country": "Armenia",
+    "country": "ARM",
     "location": "Yerevan",
     "stadium": "Vanadzor City Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Armenia",
-          "probability": 0.78
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "China",
-          "probability": 0.05
-        },
-        {
-          "name": "Austria",
-          "probability": 0.05
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 63,
       "sigma": 27
     }
   },
   {
     "name": "Central Coast Mariners",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Gosford",
     "stadium": "Central Coast Stadium",
     "stadium_capacity": 20059,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.81
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 17
     }
   },
   {
     "name": "South Melbourne",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Melbourne",
     "stadium": "Lakeside Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.82
-        },
-        {
-          "name": "Japan",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        },
-        {
-          "name": "China",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        }
-      ],
       "mu": 61,
       "sigma": 13
     }
   },
   {
     "name": "Marconi Stallions",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Sydney",
     "stadium": "Marconi Stadium",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.82
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 10
     }
   },
   {
     "name": "Sutherland Sharks",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Sydney",
     "stadium": "Seymour Shaw Park",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.85
-        },
-        {
-          "name": "China",
-          "probability": 0.08
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.08
-        }
-      ],
       "mu": 54,
       "sigma": 13
     }
   },
   {
     "name": "Sydney United 58",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Sydney",
     "stadium": "Sydney United Sports Centre",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.76
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.24
-        }
-      ],
       "mu": 61,
       "sigma": 7
     }
   },
   {
     "name": "Oakleigh Cannons",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Oakleigh",
     "stadium": "Jack Edwards Reserve",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.75
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.25
-        }
-      ],
       "mu": 63,
       "sigma": 11
     }
   },
   {
     "name": "Green Gully SC",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Melbourne",
     "stadium": "Green Gully Reserve",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.86
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.03
-        }
-      ],
       "mu": 70,
       "sigma": 24
     }
   },
   {
     "name": "Bonnyrigg White Eagles",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Sydney",
     "stadium": "Bonnyrigg Sports Club",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.83
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "France",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        }
-      ],
       "mu": 45,
       "sigma": 19
     }
   },
   {
     "name": "Inglewood United SC",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Perth",
     "stadium": "Inglewood Stadium",
     "stadium_capacity": 5536,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.71
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.1
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.1
-        },
-        {
-          "name": "India",
-          "probability": 0.1
-        }
-      ],
       "mu": 54,
       "sigma": 35
     }
   },
   {
     "name": "Northern Tigers",
-    "country": "Australia",
+    "country": "AUS",
     "location": "Sydney",
     "stadium": "Mills Park",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Australia",
-          "probability": 0.84
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.03
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.03
-        }
-      ],
       "mu": 60,
       "sigma": 12
     }
   },
   {
     "name": "Kapfenberger SV",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Kapfenberg",
     "stadium": "Franz-Fekete-Stadion",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.74
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.26
-        }
-      ],
       "mu": 76,
       "sigma": 35
     }
   },
   {
     "name": "FC Lustenau 07",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Lustenau",
     "stadium": "Reichshofstadion",
     "stadium_capacity": 8800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.71
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.29
-        }
-      ],
       "mu": 64,
       "sigma": 20
     }
   },
   {
     "name": "Austria Lustenau",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Lustenau",
     "stadium": "Reichshofstadion",
     "stadium_capacity": 8800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.71
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.29
-        }
-      ],
       "mu": 61,
       "sigma": 27
     }
   },
   {
     "name": "SKN St.P\\u00f6lten",
-    "country": "Austria",
+    "country": "AUT",
     "location": "St.P\\u00f6lten",
     "stadium": "NV Arena",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.77
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.23
-        }
-      ],
       "mu": 61,
       "sigma": 15
     }
   },
   {
     "name": "SAK Celovec/Klagenfurt",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Klagenfurt",
     "stadium": "Stadion SAK",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.79
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 21
     }
   },
   {
     "name": "SC Ritzing",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Ritzing",
     "stadium": "Sonnenseestadion",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.85
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.08
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.08
-        }
-      ],
       "mu": 80,
       "sigma": 7
     }
   },
   {
     "name": "FC Dornbirn 1913",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Dornbirn",
     "stadium": "Stadion Birkenwiese",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.72
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        },
-        {
-          "name": "Romania",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        }
-      ],
       "mu": 76,
       "sigma": 27
     }
   },
   {
     "name": "FC Kufstein",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Kufstein",
     "stadium": "Kufstein Arena",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.76
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Norway",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        }
-      ],
       "mu": 75,
       "sigma": 9
     }
   },
   {
     "name": "SV Lafnitz",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Lafnitz",
     "stadium": "Sportplatz Lafnitz",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.78
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.04
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 15
     }
   },
   {
     "name": "ASK Voitsberg",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Voitsberg",
     "stadium": "Hans Bl\\u00fcmel Stadion",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.74
-        },
-        {
-          "name": "Israel",
-          "probability": 0.26
-        }
-      ],
       "mu": 77,
       "sigma": 22
     }
   },
   {
     "name": "Wiener Sport-Club",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Vienna",
     "stadium": "Sportclubplatz",
     "stadium_capacity": 7828,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.78
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.22
-        }
-      ],
       "mu": 71,
       "sigma": 28
     }
   },
   {
     "name": "ASK Ebreichsdorf",
-    "country": "Austria",
+    "country": "AUT",
     "location": "Ebreichsdorf",
     "stadium": "Sportzentrum Ebreichsdorf",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Austria",
-          "probability": 0.85
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.15
-        }
-      ],
       "mu": 48,
       "sigma": 22
     }
   },
   {
     "name": "Samaxi FK",
-    "country": "Azerbaijan",
+    "country": "AZE",
     "location": "Baku",
     "stadium": "Inter Arena",
     "stadium_capacity": 8125,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Azerbaijan",
-          "probability": 0.83
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        }
-      ],
       "mu": 67,
       "sigma": 7
     }
   },
   {
     "name": "FK Qarabag",
-    "country": "Azerbaijan",
+    "country": "AZE",
     "location": "Aghdam",
     "stadium": "Guzanli Olympic Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Azerbaijan",
-          "probability": 0.89
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.02
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.02
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.02
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.02
-        },
-        {
-          "name": "Albania",
-          "probability": 0.02
-        }
-      ],
       "mu": 65,
       "sigma": 11
     }
   },
   {
     "name": "Turan PFK",
-    "country": "Azerbaijan",
+    "country": "AZE",
     "location": "Tovuz",
     "stadium": "Tovuz City Stadium",
     "stadium_capacity": 6800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Azerbaijan",
-          "probability": 0.75
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.12
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.12
-        }
-      ],
       "mu": 48,
       "sigma": 24
     }
   },
   {
     "name": "Energetik FK",
-    "country": "Azerbaijan",
+    "country": "AZE",
     "location": "Mingachevir",
     "stadium": "Yashar Mammadzade",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Azerbaijan",
-          "probability": 0.77
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.08
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.08
-        },
-        {
-          "name": "Albania",
-          "probability": 0.08
-        }
-      ],
       "mu": 81,
       "sigma": 29
     }
   },
   {
     "name": "Al Riffa SC",
-    "country": "Bahrain",
+    "country": "BHR",
     "location": "RIffa",
     "stadium": "Bahrain National Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bahrain",
-          "probability": 0.71
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.07
-        },
-        {
-          "name": "Oman",
-          "probability": 0.07
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.07
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        }
-      ],
       "mu": 76,
       "sigma": 16
     }
   },
   {
     "name": "Al Hala SC",
-    "country": "Bahrain",
+    "country": "BHR",
     "location": "Halat Bu Maher",
     "stadium": "Bahrain National Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bahrain",
-          "probability": 0.84
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.03
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.03
-        }
-      ],
       "mu": 53,
       "sigma": 24
     }
   },
   {
     "name": "Manama Club",
-    "country": "Bahrain",
+    "country": "BHR",
     "location": "Manama",
     "stadium": "Bahrain National Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bahrain",
-          "probability": 0.83
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        }
-      ],
       "mu": 67,
       "sigma": 11
     }
   },
   {
     "name": "Sheikh Jamal DC",
-    "country": "Bangladesh",
+    "country": "BAN",
     "location": "Dhanmondi",
     "stadium": "Sheikh Jamal Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bangladesh",
-          "probability": 0.78
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.07
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.07
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 11
     }
   },
   {
     "name": "Sheikh Russel KC",
-    "country": "Bangladesh",
+    "country": "BAN",
     "location": "Dhaka",
     "stadium": "Sylhet District Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bangladesh",
-          "probability": 0.71
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.1
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.1
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.1
-        }
-      ],
       "mu": 77,
       "sigma": 20
     }
   },
   {
     "name": "Neman Grodno",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Grodno",
     "stadium": "Neman",
     "stadium_capacity": 6300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.71
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.07
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.07
-        },
-        {
-          "name": "China",
-          "probability": 0.07
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        }
-      ],
       "mu": 70,
       "sigma": 33
     }
   },
   {
     "name": "Shakhtyor Soligorsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Soligorsk",
     "stadium": "Shakhtsyor Stadion",
     "stadium_capacity": 3030,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.84
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.08
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.08
-        }
-      ],
       "mu": 75,
       "sigma": 32
     }
   },
   {
     "name": "Granit Mikashevichi",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Mikashevichy",
     "stadium": "Brestskiy",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.89
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.03
-        },
-        {
-          "name": "Albania",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.03
-        }
-      ],
       "mu": 67,
       "sigma": 10
     }
   },
   {
     "name": "FC Slutsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Slutsk",
     "stadium": "City Stadium Slutsk",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.84
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 28
     }
   },
   {
     "name": "Krumkachy Minsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Minsk",
     "stadium": "SOK Olympijskij",
     "stadium_capacity": 1630,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.89
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.11
-        }
-      ],
       "mu": 74,
       "sigma": 16
     }
   },
   {
     "name": "Luch Minsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Minsk",
     "stadium": "SOK Olympijskij",
     "stadium_capacity": 1630,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.77
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        }
-      ],
       "mu": 46,
       "sigma": 22
     }
   },
   {
     "name": "Torpedo Minsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Minsk",
     "stadium": "Torpedo Stadium",
     "stadium_capacity": 4800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.83
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 11
     }
   },
   {
     "name": "Sputnik Rechitsa",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Rechitsa",
     "stadium": "Tsentralny",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.9
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.1
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "Volna Pinsk",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Pinsk",
     "stadium": "Volna Stadium",
     "stadium_capacity": 3136,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.76
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 24
     }
   },
   {
     "name": "Fk Baranovichi",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Baranovichi",
     "stadium": "Lokomotiv Stadium",
     "stadium_capacity": 3749,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.87
-        },
-        {
-          "name": "Romania",
-          "probability": 0.13
-        }
-      ],
       "mu": 51,
       "sigma": 21
     }
   },
   {
     "name": "FK Ostrovets",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Ostrovets",
     "stadium": "Tsentralny",
     "stadium_capacity": 1006,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.78
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        }
-      ],
       "mu": 46,
       "sigma": 5
     }
   },
   {
     "name": "FK Osipovichi",
-    "country": "Belarus",
+    "country": "BLR",
     "location": "Osipovichi",
     "stadium": "Yunost Stadium Osipovichi",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belarus",
-          "probability": 0.89
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.03
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        }
-      ],
       "mu": 77,
       "sigma": 9
     }
   },
   {
     "name": "KVC Westerlo",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Westerlo",
     "stadium": "Het Kuipje",
     "stadium_capacity": 7903,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.79
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.21
-        }
-      ],
       "mu": 73,
       "sigma": 29
     }
   },
   {
     "name": "KSV Roeselare",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Roeselare",
     "stadium": "Schiervelde",
     "stadium_capacity": 9536,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.83
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.03
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.03
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 30
     }
   },
   {
     "name": "Royal Excel Mouscron",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Mouscron",
     "stadium": "Stade Le Canonnier",
     "stadium_capacity": 11300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.75
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.06
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.06
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 28
     }
   },
   {
     "name": "Cercle Brugge",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Bruges",
     "stadium": "Jan Breydel Stadion",
     "stadium_capacity": 29024,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.72
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "Wales",
-          "probability": 0.06
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.06
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "China",
-          "probability": 0.06
-        }
-      ],
       "mu": 46,
       "sigma": 21
     }
   },
   {
     "name": "Sint-Truidense VV",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Sint-Truiden",
     "stadium": "Stayen",
     "stadium_capacity": 14600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.85
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.03
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.03
-        }
-      ],
       "mu": 64,
       "sigma": 30
     }
   },
   {
     "name": "SK Beveren",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Beveren",
     "stadium": "Freethielstadion",
     "stadium_capacity": 8190,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.8
-        },
-        {
-          "name": "Panama",
-          "probability": 0.2
-        }
-      ],
       "mu": 59,
       "sigma": 6
     }
   },
   {
     "name": "La Louvi\\u00e8re",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "La Louvi\\u00e8re",
     "stadium": "Stade du Tivoli",
     "stadium_capacity": 13500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.88
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        }
-      ],
       "mu": 69,
       "sigma": 12
     }
   },
   {
     "name": "Royal Antwerp",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Antwerp",
     "stadium": "Bosuilstadion",
     "stadium_capacity": 16649,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.76
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.08
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.08
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.08
-        }
-      ],
       "mu": 51,
       "sigma": 20
     }
   },
   {
     "name": "RFC Seraing",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Boussu",
     "stadium": "Stade Pairay",
     "stadium_capacity": 14236,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.75
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.12
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.12
-        }
-      ],
       "mu": 64,
       "sigma": 15
     }
   },
   {
     "name": "CS Vis\\u00e9",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Vis\\u00e9",
     "stadium": "Stade de la Cit\\u00e9 de l'Oie",
     "stadium_capacity": 5400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.77
-        },
-        {
-          "name": "United States",
-          "probability": 0.23
-        }
-      ],
       "mu": 46,
       "sigma": 15
     }
   },
   {
     "name": "KSK Heist",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Heist-op-den-Berg",
     "stadium": "Gemeentelijk Sportcentrum",
     "stadium_capacity": 6600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.71
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.29
-        }
-      ],
       "mu": 80,
       "sigma": 35
     }
   },
   {
     "name": "KFC Dessel Sport",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Dessel",
     "stadium": "Armand Melisstadion",
     "stadium_capacity": 4291,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.89
-        },
-        {
-          "name": "England",
-          "probability": 0.11
-        }
-      ],
       "mu": 84,
       "sigma": 15
     }
   },
   {
     "name": "Hoogstraten VV",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Hoogstraten",
     "stadium": "Sportcomplex Seminarie",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.88
-        },
-        {
-          "name": "Panama",
-          "probability": 0.02
-        },
-        {
-          "name": "Angola",
-          "probability": 0.02
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.02
-        }
-      ],
       "mu": 56,
       "sigma": 32
     }
   },
   {
     "name": "Racing Mechelen",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Mechelen",
     "stadium": "Oscar Vankesbeeck",
     "stadium_capacity": 13687,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.71
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.29
-        }
-      ],
       "mu": 63,
       "sigma": 16
     }
   },
   {
     "name": "KSV Bornem",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Bornem",
     "stadium": "Het Breeven",
     "stadium_capacity": 3450,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.87
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.07
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.07
-        }
-      ],
       "mu": 66,
       "sigma": 17
     }
   },
   {
     "name": "Lierse Kempenzonen",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Lier",
     "stadium": "Herman Vanderpoortenstadion",
     "stadium_capacity": 14537,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.82
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.06
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.06
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 10
     }
   },
   {
     "name": "KV Woluwe-Zaventem",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Zaventem",
     "stadium": "Gemeentelijk Sportstadion",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.85
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.04
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.04
-        }
-      ],
       "mu": 64,
       "sigma": 19
     }
   },
   {
     "name": "Royal Charleroi Fleurus",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Charleroi",
     "stadium": "Stade de la Neuville",
     "stadium_capacity": 12164,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.74
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.09
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.09
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.09
-        }
-      ],
       "mu": 51,
       "sigma": 16
     }
   },
   {
     "name": "FC Gullegem",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Gullegem",
     "stadium": "Stadion FC Gullegem",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.82
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 33
     }
   },
   {
     "name": "Eendracht Zele",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Zele",
     "stadium": "Ter Elst Stadium",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.71
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Canada",
-          "probability": 0.06
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.06
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 16
     }
   },
   {
     "name": "SL 16 FC",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Li\\u00e8ge",
     "stadium": "Maurice Dufrasne Stadion",
     "stadium_capacity": 29173,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.86
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.07
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        }
-      ],
       "mu": 63,
       "sigma": 31
     }
   },
   {
     "name": "Jong Genk",
-    "country": "Belgium",
+    "country": "BEL",
     "location": "Genk",
     "stadium": "Luminus Arena",
     "stadium_capacity": 24604,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Belgium",
-          "probability": 0.76
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 30
     }
   },
   {
     "name": "Bol\\u00edvar",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "La Paz",
     "stadium": "Hernando Siles",
     "stadium_capacity": 42000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.86
-        },
-        {
-          "name": "Canada",
-          "probability": 0.07
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 10
     }
   },
   {
     "name": "La Paz FC",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "La Paz",
     "stadium": "Hernando Siles",
     "stadium_capacity": 42000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.75
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.25
-        }
-      ],
       "mu": 63,
       "sigma": 14
     }
   },
   {
     "name": "Universitario de Sucre",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Sucre",
     "stadium": "Estadio Patria",
     "stadium_capacity": 32000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.79
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.04
-        }
-      ],
       "mu": 63,
       "sigma": 30
     }
   },
   {
     "name": "Club Aurora",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Cochabamba",
     "stadium": "Felix Capriles Cochabamba",
     "stadium_capacity": 32000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.76
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.24
-        }
-      ],
       "mu": 50,
       "sigma": 7
     }
   },
   {
     "name": "Club Petrolero",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Yacuiba",
     "stadium": "Provincial de Yacuiba",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.81
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.06
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        }
-      ],
       "mu": 69,
       "sigma": 26
     }
   },
   {
     "name": "CD Guabir\\u00e1",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Montero",
     "stadium": "Gilberto Parada",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.79
-        },
-        {
-          "name": "Canada",
-          "probability": 0.21
-        }
-      ],
       "mu": 62,
       "sigma": 7
     }
   },
   {
     "name": "Universitario de Vinto",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Vinto",
     "stadium": "Estadio Hip\\u00f3lito Lazarte",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.78
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.11
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.11
-        }
-      ],
       "mu": 56,
       "sigma": 13
     }
   },
   {
     "name": "Vaca D\\u00edez",
-    "country": "Bolivia",
+    "country": "BOL",
     "location": "Cobija",
     "stadium": "Estadio Roberto Jord\\u00e1n Cu\\u00e9llar",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bolivia",
-          "probability": 0.89
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.11
-        }
-      ],
       "mu": 72,
       "sigma": 35
     }
   },
   {
     "name": "NK \\u010celik",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Zenica",
     "stadium": "Bilino Polje Stadium",
     "stadium_capacity": 15700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.9
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.02
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.02
-        },
-        {
-          "name": "Japan",
-          "probability": 0.02
-        },
-        {
-          "name": "Wales",
-          "probability": 0.02
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.02
-        }
-      ],
       "mu": 49,
       "sigma": 13
     }
   },
   {
     "name": "FK Borac Banja Luka",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Banja Luka",
     "stadium": "Gradski Stadion Banja Luka",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.75
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.05
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 25
     }
   },
   {
     "name": "Sloga Doboj",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Doboj",
     "stadium": "Luke",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.71
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.07
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.07
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 7
     }
   },
   {
     "name": "Radnik Bijeljina",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Bijeljina",
     "stadium": "Gradski Bijeljina",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.87
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.13
-        }
-      ],
       "mu": 48,
       "sigma": 6
     }
   },
   {
     "name": "FK Lokomotiva Br\\u010dko",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Br\\u010dko",
     "stadium": "Lokomotiva Stadion",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.78
-        },
-        {
-          "name": "Laos",
-          "probability": 0.22
-        }
-      ],
       "mu": 69,
       "sigma": 20
     }
   },
   {
     "name": "FK Gora\\u017ede",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Gora\\u017ede",
     "stadium": "Stadion Midhat Drljevi\\u0107",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.76
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        }
-      ],
       "mu": 46,
       "sigma": 29
     }
   },
   {
     "name": "\\u017deljezni\\u010dar Banja Luka",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Banja Luka",
     "stadium": "Stadion FK \\u017deljezni\\u010dar",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.81
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 7
     }
   },
   {
     "name": "FK Igman Konjic",
-    "country": "Bosnia & Herzegovina",
+    "country": "BIH",
     "location": "Konjic",
     "stadium": "Stadion Igmana",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.9
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 11
     }
   },
   {
     "name": "Township Rollers",
-    "country": "Botswana",
+    "country": "BOT",
     "location": "Gaborone",
     "stadium": "Botswana National Stadium",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Botswana",
-          "probability": 0.84
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.03
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.03
-        }
-      ],
       "mu": 85,
       "sigma": 9
     }
   },
   {
     "name": "Ponte Preta",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Campinas",
     "stadium": "Mois\\u00e9s Lucarelli",
     "stadium_capacity": 20970,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.9
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 23
     }
   },
   {
     "name": "Gr\\u00eamio",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Porto Alegre",
     "stadium": "Arena do Gr\\u00eamio",
     "stadium_capacity": 60540,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.14
-        }
-      ],
       "mu": 85,
       "sigma": 24
     }
   },
   {
     "name": "N\\u00e1utico",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Recife",
     "stadium": "Est\\u00e1dio El\\u00e1dio de Barros Carvalho",
     "stadium_capacity": 19800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.82
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Austria",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 26
     }
   },
   {
     "name": "EC Vit\\u00f3ria",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Salvador",
     "stadium": "Barrad\\u00e3o",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.75
-        },
-        {
-          "name": "Greece",
-          "probability": 0.12
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.12
-        }
-      ],
       "mu": 80,
       "sigma": 11
     }
   },
   {
     "name": "Gr\\u00eamio Barueri",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Barueri",
     "stadium": "Arena Barueri",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.72
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.06
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.06
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.06
-        },
-        {
-          "name": "Italy",
-          "probability": 0.06
-        }
-      ],
       "mu": 77,
       "sigma": 19
     }
   },
   {
     "name": "Vila Nova",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Goi\\u00e1s",
     "stadium": "Serra Dourada",
     "stadium_capacity": 50049,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.8
-        },
-        {
-          "name": "Malta",
-          "probability": 0.2
-        }
-      ],
       "mu": 58,
       "sigma": 16
     }
   },
   {
     "name": "Cear\\u00e1 SC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Fortaleza",
     "stadium": "Arena Castel\\u00e3o",
     "stadium_capacity": 67000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.04
-        }
-      ],
       "mu": 45,
       "sigma": 35
     }
   },
   {
     "name": "Guarani FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Campinas",
     "stadium": "Brinco de Ouro da Princesa",
     "stadium_capacity": 30988,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.71
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.29
-        }
-      ],
       "mu": 79,
       "sigma": 30
     }
   },
   {
     "name": "Duque de Caxias",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Duque de Caxias",
     "stadium": "Rom\\u00e1rio de Souza Faria",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.81
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        }
-      ],
       "mu": 53,
       "sigma": 14
     }
   },
   {
     "name": "Salgueiro AC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Salgueiro",
     "stadium": "Salgueir\\u00e3o",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.73
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.27
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "SER Caxias do Sul",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Caxias do Sul",
     "stadium": "Centen\\u00e1rio",
     "stadium_capacity": 30822,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.77
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.11
-        },
-        {
-          "name": "Chile",
-          "probability": 0.11
-        }
-      ],
       "mu": 59,
       "sigma": 16
     }
   },
   {
     "name": "Clube de Regatas Brasil",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Macei\\u00f3",
     "stadium": "Est\\u00e1dio Rei Pel\\u00e9",
     "stadium_capacity": 19105,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.72
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.09
-        },
-        {
-          "name": "Japan",
-          "probability": 0.09
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.09
-        }
-      ],
       "mu": 83,
       "sigma": 34
     }
   },
   {
     "name": "Chapecoense AF",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Chapec\\u00f3",
     "stadium": "Arena Cond\\u00e1",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Austria",
-          "probability": 0.09
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.09
-        }
-      ],
       "mu": 53,
       "sigma": 17
     }
   },
   {
     "name": "Mogi Mirim EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Mogi Mirim",
     "stadium": "Est\\u00e1dio Vail Chaves",
     "stadium_capacity": 19900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.85
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.15
-        }
-      ],
       "mu": 78,
       "sigma": 29
     }
   },
   {
     "name": "CRA Catalano",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Catal\\u00e3o",
     "stadium": "Genervino Evangelista da Fonseca",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.73
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.14
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.14
-        }
-      ],
       "mu": 50,
       "sigma": 10
     }
   },
   {
     "name": "Goian\\u00e9sia EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Goian\\u00e9sia (GO)",
     "stadium": "Valdeir Jos\\u00e9 de Oliveira",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.82
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 7
     }
   },
   {
     "name": "Mar\\u00edlia AC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Mar\\u00edlia",
     "stadium": "Bento de Abreu",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.89
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.11
-        }
-      ],
       "mu": 67,
       "sigma": 21
     }
   },
   {
     "name": "EC Aracruz",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Aracruz",
     "stadium": "Est\\u00e1dio do Bambu",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Poland",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 33
     }
   },
   {
     "name": "RB Brasil",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Campinas",
     "stadium": "Mois\\u00e9s Lucarelli",
     "stadium_capacity": 20970,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.73
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.14
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.14
-        }
-      ],
       "mu": 76,
       "sigma": 35
     }
   },
   {
     "name": "Desportivo Brasil",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Porto Feliz",
     "stadium": "Municipal Alfredo Chiavegato",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.06
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 24
     }
   },
   {
     "name": "\\u00c1guia Negra",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Rio Brilhante (MS)",
     "stadium": "Ninho da \\u00c1guia",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.82
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.05
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 14
     }
   },
   {
     "name": "CN Marc\\u00edlio Dias",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Itaja\\u00ed",
     "stadium": "Dr. Hercilio Luz",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.77
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.05
-        }
-      ],
       "mu": 70,
       "sigma": 34
     }
   },
   {
     "name": "Tombense FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Tombos",
     "stadium": "Ant\\u00f4nio Guimar\\u00e3es de Almeida",
     "stadium_capacity": 3050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.89
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.11
-        }
-      ],
       "mu": 48,
       "sigma": 17
     }
   },
   {
     "name": "Porto CE",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Carauru",
     "stadium": "Lacerd\\u00e3o",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.88
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.06
-        },
-        {
-          "name": "Laos",
-          "probability": 0.06
-        }
-      ],
       "mu": 67,
       "sigma": 13
     }
   },
   {
     "name": "Serra Macaense ",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Maca\\u00e9",
     "stadium": "Cl\\u00e1udio Moacyr de Azevedo",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.9
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.02
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.02
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.02
-        },
-        {
-          "name": "Albania",
-          "probability": 0.02
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.02
-        }
-      ],
       "mu": 60,
       "sigma": 25
     }
   },
   {
     "name": "Rio Branco FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Rio Branco - AC",
     "stadium": "Arena da Floresta",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.82
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.06
-        },
-        {
-          "name": "Norway",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 21
     }
   },
   {
     "name": "Guarany de Sobral",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Sobral (CE)",
     "stadium": "Junco",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.73
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.27
-        }
-      ],
       "mu": 49,
       "sigma": 29
     }
   },
   {
     "name": "AD Cabofriense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Cabo Frio (RJ)",
     "stadium": "Est\\u00e1dio Alair C\\u00f4rrea",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.09
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.09
-        }
-      ],
       "mu": 66,
       "sigma": 14
     }
   },
   {
     "name": "AE Tiradentes",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Fortaleza",
     "stadium": "Presidente Vargas Fortaleza",
     "stadium_capacity": 20268,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.09
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.09
-        }
-      ],
       "mu": 65,
       "sigma": 25
     }
   },
   {
     "name": "AE Velo Clube",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Rio Claro",
     "stadium": "Benit\\u00e3o",
     "stadium_capacity": 8136,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.8
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.04
-        }
-      ],
       "mu": 74,
       "sigma": 12
     }
   },
   {
     "name": "S\\u00e3o Bernardo FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "S\\u00e3o Bernardo do Campo",
     "stadium": "Primeiro de Maio",
     "stadium_capacity": 13440,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.88
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 31
     }
   },
   {
     "name": "Uni\\u00e3o Barbarense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Santa B\\u00e1rbara d'Oeste",
     "stadium": "Ant\\u00f4nio R. Guimar\\u00e3es",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.73
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        }
-      ],
       "mu": 76,
       "sigma": 10
     }
   },
   {
     "name": "CA Joseense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "S\\u00e3o Jos\\u00e9 dos Campos",
     "stadium": "Est\\u00e1dio ADC Parahyba",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 31
     }
   },
   {
     "name": "Villa Nova AC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Nova Lima",
     "stadium": "Castor Cifuentes",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.04
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.04
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 30
     }
   },
   {
     "name": "Rio Preto EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "S\\u00e3o Jos\\u00e9 do Rio Preto",
     "stadium": "Est\\u00e1dio An\\u00edsio Haddad",
     "stadium_capacity": 33000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.89
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.05
-        }
-      ],
       "mu": 63,
       "sigma": 8
     }
   },
   {
     "name": "Ceil\\u00e2ndia EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Ceil\\u00e2ndia",
     "stadium": "Abadi\\u00e3o",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.03
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.03
-        }
-      ],
       "mu": 67,
       "sigma": 9
     }
   },
   {
     "name": "SE Patrocinense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Patroc\\u00ednio",
     "stadium": "Est\\u00e1dio J\\u00falio Aguiar",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.81
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        }
-      ],
       "mu": 53,
       "sigma": 32
     }
   },
   {
     "name": "AD Confian\\u00e7a",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Aracaju",
     "stadium": "Est\\u00e1dio Lourival Baptista",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.8
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.2
-        }
-      ],
       "mu": 76,
       "sigma": 14
     }
   },
   {
     "name": "Paragominas FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Paragominas",
     "stadium": "Arena Verde",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.71
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.06
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 12
     }
   },
   {
     "name": "Esportivo BG",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Bento Gon\\u00e7alves",
     "stadium": "Montanha dos Vinhedos",
     "stadium_capacity": 15269,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.74
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.26
-        }
-      ],
       "mu": 75,
       "sigma": 9
     }
   },
   {
     "name": "Clube Sociedade Esportiva",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Palmeira dos \\u00cdndios",
     "stadium": "Est\\u00e1dio Juca Sampaio",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.09
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.09
-        }
-      ],
       "mu": 66,
       "sigma": 15
     }
   },
   {
     "name": "Atl\\u00e9tico Hermann Aichinger",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Ibirama",
     "stadium": "Est\\u00e1dio da Baixada",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 17
     }
   },
   {
     "name": "Serrano SC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Vit\\u00f3ria da Conquista",
     "stadium": "Lomant\\u00e3o",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 35
     }
   },
   {
     "name": "EC Internacional",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Lages",
     "stadium": "Vidal Ramos J\\u00fanior",
     "stadium_capacity": 11800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.81
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 6
     }
   },
   {
     "name": "EC Avenida",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Santa Cruz do Sul",
     "stadium": "Est\\u00e1dio dos Eucaliptos",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.75
-        },
-        {
-          "name": "Greece",
-          "probability": 0.12
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.12
-        }
-      ],
       "mu": 74,
       "sigma": 18
     }
   },
   {
     "name": "Legi\\u00e3o FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Bras\\u00edlia",
     "stadium": "Est\\u00e1dio Nacional Man\\u00e9 Garrincha",
     "stadium_capacity": 69349,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.81
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.09
-        },
-        {
-          "name": "Israel",
-          "probability": 0.09
-        }
-      ],
       "mu": 76,
       "sigma": 17
     }
   },
   {
     "name": "XV de Ja\\u00fa",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Ja\\u00fa",
     "stadium": "Jauz\\u00e3o",
     "stadium_capacity": 13040,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.14
-        }
-      ],
       "mu": 56,
       "sigma": 31
     }
   },
   {
     "name": "EC Primavera",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Indaiatuba",
     "stadium": "\\u00cdtalo M\\u00e1rio Limongi",
     "stadium_capacity": 10220,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.86
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 12
     }
   },
   {
     "name": "EC Noroeste",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Bauru",
     "stadium": "Alfredo de Castilho",
     "stadium_capacity": 18840,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.77
-        },
-        {
-          "name": "Norway",
-          "probability": 0.23
-        }
-      ],
       "mu": 48,
       "sigma": 8
     }
   },
   {
     "name": "Globo FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Cear\\u00e1 Mirim",
     "stadium": "Barret\\u00e3o",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.76
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.06
-        },
-        {
-          "name": "Iran",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        }
-      ],
       "mu": 60,
       "sigma": 9
     }
   },
   {
     "name": "URT",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Patos de Minas",
     "stadium": "Est\\u00e1dio Zama Maciel",
     "stadium_capacity": 2800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.9
-        },
-        {
-          "name": "Iran",
-          "probability": 0.02
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.02
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        }
-      ],
       "mu": 55,
       "sigma": 27
     }
   },
   {
     "name": "S\\u00e3o Gon\\u00e7alo EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "S\\u00e3o Gon\\u00e7alo",
     "stadium": "Clube Esportivo Mau\\u00e1",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.79
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.1
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.1
-        }
-      ],
       "mu": 65,
       "sigma": 16
     }
   },
   {
     "name": "Nacional AC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Rol\\u00e2ndia",
     "stadium": "Est\\u00e1dio Erich George",
     "stadium_capacity": 2200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.77
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.23
-        }
-      ],
       "mu": 69,
       "sigma": 18
     }
   },
   {
     "name": "Conc\\u00f3rdia FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Conc\\u00f3rdia",
     "stadium": "Domingos Machado de Lima",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.9
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        }
-      ],
       "mu": 62,
       "sigma": 13
     }
   },
   {
     "name": "Trindade AC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Trindade",
     "stadium": "Est\\u00e1dio Abr\\u00e3o Manoel da Costa",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.77
-        },
-        {
-          "name": "Wales",
-          "probability": 0.23
-        }
-      ],
       "mu": 76,
       "sigma": 29
     }
   },
   {
     "name": "GE Gl\\u00f3ria",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Vacaria",
     "stadium": "Est\\u00e1dio Altos da Gl\\u00f3ria",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.76
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.12
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.12
-        }
-      ],
       "mu": 74,
       "sigma": 14
     }
   },
   {
     "name": "EC Jacuipense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Riach\\u00e3o do Jacu\\u00edpe",
     "stadium": "Valfred\\u00e3o",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.9
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Japan",
-          "probability": 0.05
-        }
-      ],
       "mu": 79,
       "sigma": 29
     }
   },
   {
     "name": "Veran\\u00f3polis ECRC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Veran\\u00f3polis",
     "stadium": "Ant\\u00f4nio David Farina",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 33
     }
   },
   {
     "name": "SE Matonense",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Mat\\u00e3o",
     "stadium": "Est\\u00e1dio Hudson Buck Pereira",
     "stadium_capacity": 8758,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.85
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        }
-      ],
       "mu": 58,
       "sigma": 8
     }
   },
   {
     "name": "Sousa EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Sousa",
     "stadium": "Mariz\\u00e3o",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.72
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        },
-        {
-          "name": "Malta",
-          "probability": 0.06
-        },
-        {
-          "name": "Iran",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        }
-      ],
       "mu": 66,
       "sigma": 26
     }
   },
   {
     "name": "Nacional Fast Clube",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Manaus",
     "stadium": "Est\\u00e1dio da ULBRA",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.71
-        },
-        {
-          "name": "Wales",
-          "probability": 0.15
-        },
-        {
-          "name": "United States",
-          "probability": 0.15
-        }
-      ],
       "mu": 56,
       "sigma": 25
     }
   },
   {
     "name": "EC Democrata",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Governador Valadares",
     "stadium": "Mamud\\u00e3o",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.16
-        }
-      ],
       "mu": 69,
       "sigma": 18
     }
   },
   {
     "name": "Fluminense de Feira",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Feira de Santana",
     "stadium": "Est\\u00e1dio Joia da Princesa",
     "stadium_capacity": 16274,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.09
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.09
-        }
-      ],
       "mu": 52,
       "sigma": 28
     }
   },
   {
     "name": "Atl\\u00e2ntico EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Salvador",
     "stadium": "Municipal de Lauro de Freitas",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.74
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 32
     }
   },
   {
     "name": "Potiguar Mossor\\u00f3",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Mossor\\u00f3",
     "stadium": "Nogueir\\u00e3o",
     "stadium_capacity": 10400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.83
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.09
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.09
-        }
-      ],
       "mu": 45,
       "sigma": 13
     }
   },
   {
     "name": "Floresta EC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Fortaleza",
     "stadium": "Felipe Santiago",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.72
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.09
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.09
-        },
-        {
-          "name": "Germany",
-          "probability": 0.09
-        }
-      ],
       "mu": 74,
       "sigma": 8
     }
   },
   {
     "name": "Sinop FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Sinop",
     "stadium": "Est\\u00e1dio Gigante do Norte",
     "stadium_capacity": 13000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.87
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 8
     }
   },
   {
     "name": "EC Pr\\u00f3spera",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Crici\\u00fama",
     "stadium": "Est\\u00e1dio Engenheiro M\\u00e1rio Balsini",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.81
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 6
     }
   },
   {
     "name": "Retr\\u00f4 FC",
-    "country": "Brazil",
+    "country": "BRA",
     "location": "Camaragibe",
     "stadium": "Itaipava Arena Pernambuco",
     "stadium_capacity": 46610,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Brazil",
-          "probability": 0.84
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 22
     }
   },
   {
     "name": "Lokomotiv Sofia",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Sofia",
     "stadium": "Lokomotiv Stadium",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.85
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        }
-      ],
       "mu": 70,
       "sigma": 29
     }
   },
   {
     "name": "Beroe Stara Zagora",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Stara Zagora",
     "stadium": "Beroe Stadium",
     "stadium_capacity": 12128,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.81
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        }
-      ],
       "mu": 46,
       "sigma": 30
     }
   },
   {
     "name": "Rilski Sportist",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Samokov",
     "stadium": "Iskar",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.87
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.13
-        }
-      ],
       "mu": 57,
       "sigma": 24
     }
   },
   {
     "name": "Sportist Svoge",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Svoge",
     "stadium": "Chavdar Cvetkov",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.75
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.06
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        },
-        {
-          "name": "Italy",
-          "probability": 0.06
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        }
-      ],
       "mu": 65,
       "sigma": 13
     }
   },
   {
     "name": "Kaliakra",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Kavarna",
     "stadium": "Gradski (Kavarna)",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.74
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.13
-        },
-        {
-          "name": "Romania",
-          "probability": 0.13
-        }
-      ],
       "mu": 70,
       "sigma": 20
     }
   },
   {
     "name": "Etar 1924",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Veliko Tarnovo",
     "stadium": "Ivaylo",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.86
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        }
-      ],
       "mu": 71,
       "sigma": 11
     }
   },
   {
     "name": "FC Bansko",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Bansko",
     "stadium": "Sveti Petar",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.76
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.12
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.12
-        }
-      ],
       "mu": 78,
       "sigma": 27
     }
   },
   {
     "name": "FC Lyubimets 2007",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Lyubimets",
     "stadium": "Gradski Stadium (Lyubimets)",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.89
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.02
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.02
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.02
-        },
-        {
-          "name": "China",
-          "probability": 0.02
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.02
-        }
-      ],
       "mu": 60,
       "sigma": 27
     }
   },
   {
     "name": "FC Rakovski",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Rakovski",
     "stadium": "Legia",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.83
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.04
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        }
-      ],
       "mu": 61,
       "sigma": 10
     }
   },
   {
     "name": "FC Sozopol",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Sozopol",
     "stadium": "Arena Sozopol",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.71
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.15
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.15
-        }
-      ],
       "mu": 63,
       "sigma": 33
     }
   },
   {
     "name": "FC Vereya",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Stara Zagora",
     "stadium": "Trace Arena",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.85
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.08
-        },
-        {
-          "name": "Panama",
-          "probability": 0.08
-        }
-      ],
       "mu": 79,
       "sigma": 12
     }
   },
   {
     "name": "CSKA Sofia II",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Sofia",
     "stadium": "Balgarska Armia",
     "stadium_capacity": 22015,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.72
-        },
-        {
-          "name": "Romania",
-          "probability": 0.28
-        }
-      ],
       "mu": 56,
       "sigma": 24
     }
   },
   {
     "name": "Kariana Erden",
-    "country": "Bulgaria",
+    "country": "BUL",
     "location": "Erden",
     "stadium": "Sport Complex Kariana",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Bulgaria",
-          "probability": 0.8
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.05
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.05
-        }
-      ],
       "mu": 62,
       "sigma": 17
     }
   },
   {
     "name": "Boeung Ket",
-    "country": "Cambodia",
+    "country": "CAM",
     "location": "Phnom Penh",
     "stadium": "Cambodia Airways Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cambodia",
-          "probability": 0.72
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.09
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.09
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.09
-        }
-      ],
       "mu": 46,
       "sigma": 16
     }
   },
   {
     "name": "Canon Yaound\\u00e9",
-    "country": "Cameroon",
+    "country": "CMR",
     "location": "Yaound\\u00e9",
     "stadium": "Ahmadou Ahidjo Stadium",
     "stadium_capacity": 38720,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cameroon",
-          "probability": 0.9
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 33
     }
   },
   {
     "name": "APEJES Academy",
-    "country": "Cameroon",
+    "country": "CMR",
     "location": "Yaound\\u00e9",
     "stadium": "Ahmadou Ahidjo Stadium",
     "stadium_capacity": 38720,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cameroon",
-          "probability": 0.81
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.04
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        },
-        {
-          "name": "Togo",
-          "probability": 0.04
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.04
-        }
-      ],
       "mu": 67,
       "sigma": 17
     }
   },
   {
     "name": "Vancouver Whitecaps",
-    "country": "Canada",
+    "country": "CAN",
     "location": "Vancouver",
     "stadium": "BC Place Stadium",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Canada",
-          "probability": 0.86
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 16
     }
   },
   {
     "name": "CF Montr\\u00e9al",
-    "country": "Canada",
+    "country": "CAN",
     "location": "Montreal",
     "stadium": "Stade Saputo",
     "stadium_capacity": 20801,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Canada",
-          "probability": 0.8
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.1
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.1
-        }
-      ],
       "mu": 49,
       "sigma": 31
     }
   },
   {
     "name": "Brampton City United",
-    "country": "Canada",
+    "country": "CAN",
     "location": "Brampton",
     "stadium": "Victoria Park Stadium",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Canada",
-          "probability": 0.89
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.04
-        }
-      ],
       "mu": 70,
       "sigma": 18
     }
   },
   {
     "name": "Serbian White Eagles",
-    "country": "Canada",
+    "country": "CAN",
     "location": "Toronto",
     "stadium": "Centennial Park Stadium",
     "stadium_capacity": 2200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Canada",
-          "probability": 0.9
-        },
-        {
-          "name": "Spain",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 27
     }
   },
   {
     "name": "Forge FC",
-    "country": "Canada",
+    "country": "CAN",
     "location": "Hamilton",
     "stadium": "Tim Hortons Field",
     "stadium_capacity": 10016,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Canada",
-          "probability": 0.88
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.03
-        },
-        {
-          "name": "France",
-          "probability": 0.03
-        }
-      ],
       "mu": 58,
       "sigma": 28
     }
   },
   {
     "name": "Universidad Cat\\u00f3lica",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Santiago",
     "stadium": "San Carlos de Apoquindo",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.8
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.05
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        }
-      ],
       "mu": 79,
       "sigma": 23
     }
   },
   {
     "name": "O'Higgins FC",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Rancagua",
     "stadium": "El Teniente",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.8
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        }
-      ],
       "mu": 49,
       "sigma": 18
     }
   },
   {
     "name": "Deportes Puerto Montt",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Puerto Montt",
     "stadium": "Regional de Chinquihue",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.77
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.08
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.08
-        },
-        {
-          "name": "Russia",
-          "probability": 0.08
-        }
-      ],
       "mu": 81,
       "sigma": 27
     }
   },
   {
     "name": "Santiago Wanderers",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Valpara\\u00edso",
     "stadium": "El\\u00edas Figueroa Brander",
     "stadium_capacity": 23000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.71
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.15
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.15
-        }
-      ],
       "mu": 52,
       "sigma": 8
     }
   },
   {
     "name": "Universidad de Concepci\\u00f3n",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Concepci\\u00f3n",
     "stadium": "Estadio Municipal Ester Roa Rebolledo",
     "stadium_capacity": 30448,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.8
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.2
-        }
-      ],
       "mu": 63,
       "sigma": 27
     }
   },
   {
     "name": "Deportes Antofagasta",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Antofagasta",
     "stadium": "Regional Calvo y Bascu\\u00f1\\u00e1n",
     "stadium_capacity": 21178,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.84
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.03
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        }
-      ],
       "mu": 47,
       "sigma": 10
     }
   },
   {
     "name": "Santiago Morning",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Santiago",
     "stadium": "Municipal de La Pintana",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.74
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.07
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.07
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Greece",
-          "probability": 0.07
-        }
-      ],
       "mu": 60,
       "sigma": 23
     }
   },
   {
     "name": "Deportivo \\u00d1ublense",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Chill\\u00e1n",
     "stadium": "Nelson Oyarz\\u00fan Arenas",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.8
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.1
-        },
-        {
-          "name": "Iran",
-          "probability": 0.1
-        }
-      ],
       "mu": 72,
       "sigma": 34
     }
   },
   {
     "name": "Curic\\u00f3 Unido",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Curic\\u00f3",
     "stadium": "La Granja",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.88
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.03
-        }
-      ],
       "mu": 78,
       "sigma": 33
     }
   },
   {
     "name": "CD Trasandino",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Los Andes",
     "stadium": "Regional de Los Andes",
     "stadium_capacity": 2800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.77
-        },
-        {
-          "name": "Russia",
-          "probability": 0.06
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.06
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        }
-      ],
       "mu": 77,
       "sigma": 24
     }
   },
   {
     "name": "Deportes Vallenar",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Vallenar",
     "stadium": "Municipal Nelson Rojas",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.83
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.06
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 27
     }
   },
   {
     "name": "Lautaro de Buin",
-    "country": "Chile",
+    "country": "CHI",
     "location": "Buin",
     "stadium": "Estadio Lautaro",
     "stadium_capacity": 1100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Chile",
-          "probability": 0.9
-        },
-        {
-          "name": "Norway",
-          "probability": 0.03
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 28
     }
   },
   {
     "name": "Chongqing Liangjiang Athletic",
-    "country": "China",
+    "country": "CHN",
     "location": "Chongqing",
     "stadium": "Fuling Stadium",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.72
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.14
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.14
-        }
-      ],
       "mu": 74,
       "sigma": 20
     }
   },
   {
     "name": "Chengdu Tiancheng",
-    "country": "China",
+    "country": "CHN",
     "location": "Chengdu",
     "stadium": "Chengdu Sports Centre",
     "stadium_capacity": 40834,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.73
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.14
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.14
-        }
-      ],
       "mu": 48,
       "sigma": 6
     }
   },
   {
     "name": "Tianjin Tianhai",
-    "country": "China",
+    "country": "CHN",
     "location": "Tianjin",
     "stadium": "Tianjin Olympic Center Stadium",
     "stadium_capacity": 54696,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.71
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.15
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.15
-        }
-      ],
       "mu": 64,
       "sigma": 30
     }
   },
   {
     "name": "Zhejiang Yiteng",
-    "country": "China",
+    "country": "CHN",
     "location": "Shaoxing",
     "stadium": "Shaoxing Sports Center",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.87
-        },
-        {
-          "name": "Albania",
-          "probability": 0.07
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 26
     }
   },
   {
     "name": "Beijing IT",
-    "country": "China",
+    "country": "CHN",
     "location": "Beijing",
     "stadium": "BIT Eastern Athletic Field",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.87
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.13
-        }
-      ],
       "mu": 83,
       "sigma": 33
     }
   },
   {
     "name": "Shanghai Port",
-    "country": "China",
+    "country": "CHN",
     "location": "Shanghai",
     "stadium": "Pudong Football Stadium",
     "stadium_capacity": 37000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.9
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.02
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.02
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.02
-        },
-        {
-          "name": "England",
-          "probability": 0.02
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.02
-        }
-      ],
       "mu": 82,
       "sigma": 20
     }
   },
   {
     "name": "Cangzhou Mighty Lions",
-    "country": "China",
+    "country": "CHN",
     "location": "Shijiazhuang",
     "stadium": "Yutong International Sports Center",
     "stadium_capacity": 38500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.86
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.14
-        }
-      ],
       "mu": 77,
       "sigma": 18
     }
   },
   {
     "name": "Qingdao",
-    "country": "China",
+    "country": "CHN",
     "location": "Qingdao",
     "stadium": "Qingdao Guoxin Stadium",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.75
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 18
     }
   },
   {
     "name": "Jiangxi Beidamen",
-    "country": "China",
+    "country": "CHN",
     "location": "Nanchang",
     "stadium": "Jiangxi Olympic Sports Center",
     "stadium_capacity": 50000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.76
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.12
-        },
-        {
-          "name": "Macao",
-          "probability": 0.12
-        }
-      ],
       "mu": 84,
       "sigma": 25
     }
   },
   {
     "name": "Inner Mongolia Zhongyou",
-    "country": "China",
+    "country": "CHN",
     "location": "Taiyuan",
     "stadium": "Shanxi Sports Centre Stadium",
     "stadium_capacity": 62000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.81
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.19
-        }
-      ],
       "mu": 85,
       "sigma": 32
     }
   },
   {
     "name": "Dalian Transcendence",
-    "country": "China",
+    "country": "CHN",
     "location": "Dalian",
     "stadium": "Jinzhou",
     "stadium_capacity": 30776,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.74
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.13
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.13
-        }
-      ],
       "mu": 63,
       "sigma": 33
     }
   },
   {
     "name": "Heilongjiang Ice City",
-    "country": "China",
+    "country": "CHN",
     "location": "Harbin",
     "stadium": "Harbin Sports Centre",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.75
-        },
-        {
-          "name": "Malta",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.05
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.05
-        }
-      ],
       "mu": 52,
       "sigma": 35
     }
   },
   {
     "name": "Inner Mongolia Lanao",
-    "country": "China",
+    "country": "CHN",
     "location": "Baotou",
     "stadium": "Baotou OSC",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.79
-        },
-        {
-          "name": "United States",
-          "probability": 0.21
-        }
-      ],
       "mu": 46,
       "sigma": 7
     }
   },
   {
     "name": "Hainan Boying",
-    "country": "China",
+    "country": "CHN",
     "location": "Hainan",
     "stadium": "Hainan Sport School Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.76
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.06
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 21
     }
   },
   {
     "name": "Yinchuan Helanshan",
-    "country": "China",
+    "country": "CHN",
     "location": "Yinchuan",
     "stadium": "Helan Mountain Stadium",
     "stadium_capacity": 39872,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.8
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.2
-        }
-      ],
       "mu": 69,
       "sigma": 24
     }
   },
   {
     "name": "Guangdong Southern Tigers",
-    "country": "China",
+    "country": "CHN",
     "location": "Meizhou",
     "stadium": "Meixian Tsang Hin-chi Stadium",
     "stadium_capacity": 20221,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.86
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.14
-        }
-      ],
       "mu": 63,
       "sigma": 19
     }
   },
   {
     "name": "Kunshan FC",
-    "country": "China",
+    "country": "CHN",
     "location": "Kunshan",
     "stadium": "Zhenjiang Sports Exhibition Center",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.71
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.07
-        },
-        {
-          "name": "Russia",
-          "probability": 0.07
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.07
-        },
-        {
-          "name": "Peru",
-          "probability": 0.07
-        }
-      ],
       "mu": 52,
       "sigma": 29
     }
   },
   {
     "name": "Shenyang Dongjin",
-    "country": "China",
+    "country": "CHN",
     "location": "Shenyang",
     "stadium": "Shenyang Urban Construction University Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.72
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.06
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.06
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.06
-        }
-      ],
       "mu": 59,
       "sigma": 22
     }
   },
   {
     "name": "Wuhan Three Towns",
-    "country": "China",
+    "country": "CHN",
     "location": "Wuhan",
     "stadium": "Hankou Cultural Sports Centre",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.86
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.07
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.07
-        }
-      ],
       "mu": 56,
       "sigma": 34
     }
   },
   {
     "name": "Inner Mongolia Caoshangfei",
-    "country": "China",
+    "country": "CHN",
     "location": "Baotou",
     "stadium": "Baotou OSC",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.82
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "England",
-          "probability": 0.06
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        }
-      ],
       "mu": 77,
       "sigma": 27
     }
   },
   {
     "name": "Hangzhou Wuyue Qiantang",
-    "country": "China",
+    "country": "CHN",
     "location": "Hangzhou",
     "stadium": "Meihu Sports Centre Stadium",
     "stadium_capacity": 35260,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.76
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.06
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 18
     }
   },
   {
     "name": "Yunnan Kunlu",
-    "country": "China",
+    "country": "CHN",
     "location": "Kunming",
     "stadium": "Qujing Culture and Sports Park Stadium",
     "stadium_capacity": 34162,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "China",
-          "probability": 0.87
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.03
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.03
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        }
-      ],
       "mu": 68,
       "sigma": 21
     }
   },
   {
     "name": "Boyac\\u00e1 Chic\\u00f3",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Tunja",
     "stadium": "La Independencia",
     "stadium_capacity": 20630,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.83
-        },
-        {
-          "name": "Albania",
-          "probability": 0.17
-        }
-      ],
       "mu": 46,
       "sigma": 12
     }
   },
   {
     "name": "Deportivo Pasto",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Pasto",
     "stadium": "Libertad",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.72
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.09
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.09
-        },
-        {
-          "name": "China",
-          "probability": 0.09
-        }
-      ],
       "mu": 53,
       "sigma": 26
     }
   },
   {
     "name": "Envigado",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Envigado",
     "stadium": "Polideportivo Sur",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.78
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.22
-        }
-      ],
       "mu": 59,
       "sigma": 27
     }
   },
   {
     "name": "Independiente Medell\\u00edn",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Medell\\u00edn",
     "stadium": "Atanasio Girardot",
     "stadium_capacity": 45955,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.86
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.03
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        }
-      ],
       "mu": 84,
       "sigma": 15
     }
   },
   {
     "name": "Deportivo Pereira",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Pereira",
     "stadium": "Hern\\u00e1n Ram\\u00edrez Villegas",
     "stadium_capacity": 30313,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.78
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.22
-        }
-      ],
       "mu": 84,
       "sigma": 10
     }
   },
   {
     "name": "Independiente Santa F\\u00e9",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Bogot\\u00e1",
     "stadium": "Nemesio Camacho",
     "stadium_capacity": 47000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.8
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.07
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.07
-        }
-      ],
       "mu": 84,
       "sigma": 18
     }
   },
   {
     "name": "CD La Equidad",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Bogot\\u00e1",
     "stadium": "Metropolitano de Techo",
     "stadium_capacity": 7800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.82
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.18
-        }
-      ],
       "mu": 46,
       "sigma": 8
     }
   },
   {
     "name": "Aguilas Doradas",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Rionegro",
     "stadium": "Alberto Grisales",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.85
-        },
-        {
-          "name": "Austria",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        }
-      ],
       "mu": 71,
       "sigma": 31
     }
   },
   {
     "name": "Bogot\\u00e1 FC",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Bogot\\u00e1",
     "stadium": "Alfonso L\\u00f3pez Pumarejo",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.84
-        },
-        {
-          "name": "Norway",
-          "probability": 0.16
-        }
-      ],
       "mu": 61,
       "sigma": 13
     }
   },
   {
     "name": "Universitario Popay\\u00e1n",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Popay\\u00e1n",
     "stadium": "Ciro L\\u00f3pez",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.87
-        },
-        {
-          "name": "India",
-          "probability": 0.07
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.07
-        }
-      ],
       "mu": 45,
       "sigma": 17
     }
   },
   {
     "name": "Barranquilla FC",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Barranquilla",
     "stadium": "Romelio Mart\\u00ednez",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.77
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.06
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.06
-        }
-      ],
       "mu": 75,
       "sigma": 13
     }
   },
   {
     "name": "Real Santander",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Piedecuesta",
     "stadium": "Estadio Villa Concha",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.77
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.08
-        },
-        {
-          "name": "Romania",
-          "probability": 0.08
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.08
-        }
-      ],
       "mu": 66,
       "sigma": 26
     }
   },
   {
     "name": "Valledupar FC",
-    "country": "Colombia",
+    "country": "COL",
     "location": "Valledupar",
     "stadium": "Armando Maestre Pavajeau",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Colombia",
-          "probability": 0.86
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "France",
-          "probability": 0.07
-        }
-      ],
       "mu": 85,
       "sigma": 13
     }
   },
   {
     "name": "LD Alajuelense",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Alajuela",
     "stadium": "Alejandro Morera Soto",
     "stadium_capacity": 17895,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.86
-        },
-        {
-          "name": "Australia",
-          "probability": 0.14
-        }
-      ],
       "mu": 68,
       "sigma": 8
     }
   },
   {
     "name": "Cartagin\\u00e9s",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Cartago",
     "stadium": "Jos\\u00e9 Rafael Fello Meza Ivankovich",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.9
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        }
-      ],
       "mu": 78,
       "sigma": 24
     }
   },
   {
     "name": "Bel\\u00e9n Siglo XXI",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Bel\\u00e9n",
     "stadium": "Polideportivo de Bel\\u00e9n",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.83
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.17
-        }
-      ],
       "mu": 84,
       "sigma": 32
     }
   },
   {
     "name": "Santos de Gu\\u00e1piles",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Gu\\u00e1piles",
     "stadium": "Ebal Rodr\\u00edguez",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.72
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.07
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.07
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.07
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.07
-        }
-      ],
       "mu": 61,
       "sigma": 29
     }
   },
   {
     "name": "CS Uruguay",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Coronado",
     "stadium": "Municipal El Labrador",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.78
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.05
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        }
-      ],
       "mu": 63,
       "sigma": 11
     }
   },
   {
     "name": "Barrio M\\u00e9xico",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Guadalupe",
     "stadium": "Coyella Fonseca",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.72
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.28
-        }
-      ],
       "mu": 85,
       "sigma": 26
     }
   },
   {
     "name": "AS Puma Generale\\u00f1a",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "San Isidro de El General",
     "stadium": "Estadio Municipal Keylor Navas Gamboa",
     "stadium_capacity": 2100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.8
-        },
-        {
-          "name": "Iran",
-          "probability": 0.2
-        }
-      ],
       "mu": 81,
       "sigma": 24
     }
   },
   {
     "name": "Jac\\u00f3 Rays",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "Garabito",
     "stadium": "Municipal de Garabito",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.75
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.25
-        }
-      ],
       "mu": 63,
       "sigma": 23
     }
   },
   {
     "name": "Guadalupe FC",
-    "country": "Costa Rica",
+    "country": "CRC",
     "location": "San Jos\\u00e9",
     "stadium": "Estadio Coyella Fonseca",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Costa Rica",
-          "probability": 0.85
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        }
-      ],
       "mu": 45,
       "sigma": 8
     }
   },
   {
     "name": "NK Me\\u0111imurje",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "\\u010cakovec",
     "stadium": "SRC Mladost",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.77
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 19
     }
   },
   {
     "name": "NK Karlovac 1919",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Karlovac",
     "stadium": "Branko \\u010cavlovi\\u0107-\\u010cavlek",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.9
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 11
     }
   },
   {
     "name": "NK Lokomotiva",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Zagreb",
     "stadium": "Kranj\\u010devi\\u0107eva",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.78
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        }
-      ],
       "mu": 50,
       "sigma": 19
     }
   },
   {
     "name": "NK Zelina",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Sveti Ivan Zelina",
     "stadium": "SRC Zelina",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.87
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        }
-      ],
       "mu": 71,
       "sigma": 26
     }
   },
   {
     "name": "HNK Gorica",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Velika Gorica",
     "stadium": "Gradski stadion Velika Gorica",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.84
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 29
     }
   },
   {
     "name": "Dinamo Zagreb II",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Zagreb",
     "stadium": "Stadion Hitrec Kacian",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.8
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Panama",
-          "probability": 0.04
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.04
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 21
     }
   },
   {
     "name": "NK Maksimir",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Zagreb",
     "stadium": "Stadion Oboj",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.76
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.12
-        },
-        {
-          "name": "Albania",
-          "probability": 0.12
-        }
-      ],
       "mu": 60,
       "sigma": 28
     }
   },
   {
     "name": "NK Rovinj",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Rovinj",
     "stadium": "Stadion Valbruna",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.71
-        },
-        {
-          "name": "Wales",
-          "probability": 0.07
-        },
-        {
-          "name": "Laos",
-          "probability": 0.07
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.07
-        },
-        {
-          "name": "Italy",
-          "probability": 0.07
-        }
-      ],
       "mu": 85,
       "sigma": 29
     }
   },
   {
     "name": "HNK Orijent 1919",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Rijeka",
     "stadium": "Stadion Krimeja",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.73
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.27
-        }
-      ],
       "mu": 59,
       "sigma": 33
     }
   },
   {
     "name": "NK Dubrava",
-    "country": "Croatia",
+    "country": "CRO",
     "location": "Zagreb",
     "stadium": "SRC Dubrava",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Croatia",
-          "probability": 0.79
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.05
-        },
-        {
-          "name": "China",
-          "probability": 0.05
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 27
     }
   },
   {
     "name": "AC Omonoia Nicosia",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Nicosia",
     "stadium": "GSP",
     "stadium_capacity": 22859,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.86
-        },
-        {
-          "name": "Macao",
-          "probability": 0.14
-        }
-      ],
       "mu": 62,
       "sigma": 8
     }
   },
   {
     "name": "AEK Larnaca",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Larnaca",
     "stadium": "AEK Arena \\u2013 Georgios Karapatakis",
     "stadium_capacity": 7400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.78
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 18
     }
   },
   {
     "name": "Pafos FC",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Paphos",
     "stadium": "Pafiako",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.85
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.15
-        }
-      ],
       "mu": 63,
       "sigma": 28
     }
   },
   {
     "name": "Ayia Napa",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Ayia Napa",
     "stadium": "Tasos Markou",
     "stadium_capacity": 5800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.85
-        },
-        {
-          "name": "China",
-          "probability": 0.05
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 17
     }
   },
   {
     "name": "Omonoia Aradippou",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Aradippou",
     "stadium": "Aradippou Stadium",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.72
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.06
-        },
-        {
-          "name": "Austria",
-          "probability": 0.06
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 7
     }
   },
   {
     "name": "Digenis Oroklinis",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Oroklini",
     "stadium": "Koinotiko Stadio",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.83
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 15
     }
   },
   {
     "name": "Akritas Chlorakas",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Chlorakas",
     "stadium": "Koinotikoo Chlorakas",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.78
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.07
-        },
-        {
-          "name": "Italy",
-          "probability": 0.07
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "ASIL",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Lysi",
     "stadium": "Grigoris Afxentiou",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.74
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.26
-        }
-      ],
       "mu": 62,
       "sigma": 6
     }
   },
   {
     "name": "Onisilos Sotira",
-    "country": "Cyprus",
+    "country": "CYP",
     "location": "Sotira",
     "stadium": "Sotira Municipal Stadium",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Cyprus",
-          "probability": 0.72
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.06
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.06
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        }
-      ],
       "mu": 82,
       "sigma": 16
     }
   },
   {
     "name": "FK Teplice",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Teplice",
     "stadium": "Na St\\u00ednadlech",
     "stadium_capacity": 18221,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.87
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.07
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.07
-        }
-      ],
       "mu": 77,
       "sigma": 30
     }
   },
   {
     "name": "SK Slavia Praha",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Prague",
     "stadium": "Sinobo Stadium",
     "stadium_capacity": 21000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.86
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        }
-      ],
       "mu": 63,
       "sigma": 26
     }
   },
   {
     "name": "Sparta Praha",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Prague",
     "stadium": "Generali Arena",
     "stadium_capacity": 20558,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.74
-        },
-        {
-          "name": "Laos",
-          "probability": 0.07
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.07
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.07
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        }
-      ],
       "mu": 71,
       "sigma": 23
     }
   },
   {
     "name": "1.FK Pr\\u00edbram",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "P\\u0159\\u00edbram",
     "stadium": "Stadion Na Litavce",
     "stadium_capacity": 9100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.77
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        }
-      ],
       "mu": 76,
       "sigma": 26
     }
   },
   {
     "name": "FK Pardubice",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Pardubice",
     "stadium": "Pod Vinic\\u00ed",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.74
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.26
-        }
-      ],
       "mu": 52,
       "sigma": 17
     }
   },
   {
     "name": "Han\\u00e1ck\\u00e1 Slavia Kromeriz",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Krom\\u011b\\u0159\\u00ed\\u017e",
     "stadium": "Stadion SK Han\\u00e1ck\\u00e1 Slavia Krom\\u011b\\u0159\\u00ed\\u017e",
     "stadium_capacity": 1528,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.86
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 11
     }
   },
   {
     "name": "MFK Vy\\u0161kov",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Vy\\u0161kov",
     "stadium": "Stadion Za parkem",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.81
-        },
-        {
-          "name": "Macao",
-          "probability": 0.09
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.09
-        }
-      ],
       "mu": 63,
       "sigma": 34
     }
   },
   {
     "name": "FK Litom\\u011b\\u0159ice",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Litom\\u011b\\u0159ice",
     "stadium": "Stadion Litom\\u011b\\u0159ice",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.71
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.29
-        }
-      ],
       "mu": 48,
       "sigma": 25
     }
   },
   {
     "name": "Olympia Radot\\u00edn",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Prague",
     "stadium": "Stadion Ev\\u017eena Ro\\u0161ick\\u00e9ho",
     "stadium_capacity": 19032,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.86
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.07
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.07
-        }
-      ],
       "mu": 48,
       "sigma": 13
     }
   },
   {
     "name": "SK Lisen",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Brno",
     "stadium": "Stadion SK L\\u00ed\\u0161e\\u0148",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.85
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 33
     }
   },
   {
     "name": "Odra Petrkovice",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Ostrava",
     "stadium": "Stadion Odra Pet\\u0159kovice",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.89
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.03
-        }
-      ],
       "mu": 47,
       "sigma": 35
     }
   },
   {
     "name": "Viktoria Otrokovice",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Otrokovice",
     "stadium": "Stadion FC Viktoria Otrokovice",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.89
-        },
-        {
-          "name": "Greece",
-          "probability": 0.11
-        }
-      ],
       "mu": 59,
       "sigma": 21
     }
   },
   {
     "name": "FK Blansko",
-    "country": "Czech Republic",
+    "country": "CZE",
     "location": "Blansko",
     "stadium": "Stadion na \\u00dadoln\\u00ed",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Czech Republic",
-          "probability": 0.74
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "TP Mazembe",
-    "country": "DR Congo",
+    "country": "COD",
     "location": "Lubumbashi",
     "stadium": "Municipal de Lubumbashi",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "DR Congo",
-          "probability": 0.87
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 31
     }
   },
   {
     "name": "DC Motema Pembe",
-    "country": "DR Congo",
+    "country": "COD",
     "location": "Kinshasa",
     "stadium": "Stade des Martyrs",
     "stadium_capacity": 80000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "DR Congo",
-          "probability": 0.79
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 13
     }
   },
   {
     "name": "Brondby IF",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Br\\u00f8ndby",
     "stadium": "Br\\u00f8ndby Stadion",
     "stadium_capacity": 29000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.8
-        },
-        {
-          "name": "Canada",
-          "probability": 0.1
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.1
-        }
-      ],
       "mu": 54,
       "sigma": 8
     }
   },
   {
     "name": "FC K\\u00f8benhavn",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Copenhagen",
     "stadium": "Parken",
     "stadium_capacity": 38065,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.75
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.05
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.05
-        }
-      ],
       "mu": 54,
       "sigma": 34
     }
   },
   {
     "name": "FC Nordsjaelland",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Farum",
     "stadium": "Farum Park",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.76
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.24
-        }
-      ],
       "mu": 47,
       "sigma": 33
     }
   },
   {
     "name": "Aarhus GF",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Aarhus",
     "stadium": "Aarhus Stadium",
     "stadium_capacity": 21000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.9
-        },
-        {
-          "name": "England",
-          "probability": 0.02
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.02
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.02
-        },
-        {
-          "name": "Togo",
-          "probability": 0.02
-        }
-      ],
       "mu": 58,
       "sigma": 35
     }
   },
   {
     "name": "Naestved BK",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "N\\u00e6stved",
     "stadium": "Naestved Stadion",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.89
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 17
     }
   },
   {
     "name": "FC Helsingor",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Helsing\\u00f8r",
     "stadium": "Helsing\\u00f8r Stadion",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.83
-        },
-        {
-          "name": "United States",
-          "probability": 0.03
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.03
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        }
-      ],
       "mu": 84,
       "sigma": 15
     }
   },
   {
     "name": "Hellerup IK",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Hellerup",
     "stadium": "Gentofte Sportspark",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.9
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.05
-        }
-      ],
       "mu": 82,
       "sigma": 25
     }
   },
   {
     "name": "B.93",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Copenhagen",
     "stadium": "\\u00d8sterbro Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.81
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.04
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "BK Avarta",
-    "country": "Denmark",
+    "country": "DEN",
     "location": "Copenhagen",
     "stadium": "Espelundens Idr\\u00e6tsanl\\u00e6g",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Denmark",
-          "probability": 0.88
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        }
-      ],
       "mu": 78,
       "sigma": 12
     }
   },
   {
     "name": "Moca FC",
-    "country": "Dominican Republic",
+    "country": "DOM",
     "location": "Moca",
     "stadium": "Estadio Complejo Deportivo Moca 86",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Dominican Republic",
-          "probability": 0.83
-        },
-        {
-          "name": "Norway",
-          "probability": 0.06
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.06
-        }
-      ],
       "mu": 75,
       "sigma": 5
     }
   },
   {
     "name": "CD ESPOLI",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Latacunga",
     "stadium": "Esatdio la Cocha",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.75
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.08
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.08
-        },
-        {
-          "name": "India",
-          "probability": 0.08
-        }
-      ],
       "mu": 48,
       "sigma": 26
     }
   },
   {
     "name": "CS Macar\\u00e1",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Ambato",
     "stadium": "Estadio Bellavista",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.85
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.15
-        }
-      ],
       "mu": 76,
       "sigma": 10
     }
   },
   {
     "name": "Liga de Portoviejo",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Portoviejo",
     "stadium": "Reales Tamarindos",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.75
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.12
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.12
-        }
-      ],
       "mu": 81,
       "sigma": 17
     }
   },
   {
     "name": "Manta FC",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Manta",
     "stadium": "Jocay",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.76
-        },
-        {
-          "name": "Panama",
-          "probability": 0.24
-        }
-      ],
       "mu": 59,
       "sigma": 29
     }
   },
   {
     "name": "Independiente del Valle",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Sangolqu\\u00ed",
     "stadium": "Estadio de Independiente del Valle",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.76
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.06
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.06
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.06
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.06
-        }
-      ],
       "mu": 59,
       "sigma": 19
     }
   },
   {
     "name": "Deportivo Quevedo",
-    "country": "Ecuador",
+    "country": "ECU",
     "location": "Quevedo",
     "stadium": "7 de Octubre",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ecuador",
-          "probability": 0.88
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 14
     }
   },
   {
     "name": "Al Ahly",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Cairo",
     "stadium": "Cairo International Stadium",
     "stadium_capacity": 75000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.82
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.06
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 7
     }
   },
   {
     "name": "Ittihad",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Alexandria",
     "stadium": "Alexandria Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.88
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        },
-        {
-          "name": "Romania",
-          "probability": 0.06
-        }
-      ],
       "mu": 55,
       "sigma": 8
     }
   },
   {
     "name": "Haras El Hodood",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Alexandria",
     "stadium": "Alexandria Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.82
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.06
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 29
     }
   },
   {
     "name": "Misr el Makasa",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Fayoum",
     "stadium": "Fayoum Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.83
-        },
-        {
-          "name": "Norway",
-          "probability": 0.17
-        }
-      ],
       "mu": 61,
       "sigma": 29
     }
   },
   {
     "name": "Smouha SC",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Alexandria",
     "stadium": "Alexandria Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.89
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 13
     }
   },
   {
     "name": "Tala'ea El Gaish SC",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Cairo",
     "stadium": "Cairo Military Academy Stadium",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.77
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        }
-      ],
       "mu": 74,
       "sigma": 5
     }
   },
   {
     "name": "Aswan SC",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Aswan",
     "stadium": "Aswan Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.74
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 34
     }
   },
   {
     "name": "ZED FC",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Cairo",
     "stadium": "Maadi Olympic Center",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.87
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 29
     }
   },
   {
     "name": "Ceramica Cleopatra",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Giza",
     "stadium": "Suez Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.9
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "France",
-          "probability": 0.03
-        }
-      ],
       "mu": 70,
       "sigma": 8
     }
   },
   {
     "name": "Eastern Company SC",
-    "country": "Egypt",
+    "country": "EGY",
     "location": "Cairo",
     "stadium": "Eastern Company Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Egypt",
-          "probability": 0.75
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Angola",
-          "probability": 0.06
-        }
-      ],
       "mu": 49,
       "sigma": 19
     }
   },
   {
     "name": "LA Firpo",
-    "country": "El Salvador",
+    "country": "SLV",
     "location": "Usulut\\u00e1n",
     "stadium": "Sergio Torres",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "El Salvador",
-          "probability": 0.74
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.07
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.07
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.07
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        }
-      ],
       "mu": 45,
       "sigma": 9
     }
   },
   {
     "name": "Arsenal",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Emirates Stadium",
     "stadium_capacity": 60432,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.19
-        }
-      ],
       "mu": 56,
       "sigma": 32
     }
   },
   {
     "name": "Aston Villa",
-    "country": "England",
+    "country": "ENG",
     "location": "Birmingham",
     "stadium": "Villa Park",
     "stadium_capacity": 42788,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.88
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        }
-      ],
       "mu": 67,
       "sigma": 23
     }
   },
   {
     "name": "Barnsley",
-    "country": "England",
+    "country": "ENG",
     "location": "Barnsley",
     "stadium": "Oakwell",
     "stadium_capacity": 23009,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.84
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Norway",
-          "probability": 0.04
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 10
     }
   },
   {
     "name": "Birmingham City",
-    "country": "England",
+    "country": "ENG",
     "location": "Birmingham",
     "stadium": "St Andrews",
     "stadium_capacity": 30009,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Chile",
-          "probability": 0.25
-        }
-      ],
       "mu": 79,
       "sigma": 26
     }
   },
   {
     "name": "Blackburn Rovers",
-    "country": "England",
+    "country": "ENG",
     "location": "Blackburn",
     "stadium": "Ewood Park",
     "stadium_capacity": 31367,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.25
-        }
-      ],
       "mu": 67,
       "sigma": 15
     }
   },
   {
     "name": "Blackpool",
-    "country": "England",
+    "country": "ENG",
     "location": "Blackpool",
     "stadium": "Bloomfield Road",
     "stadium_capacity": 17338,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.1
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.1
-        }
-      ],
       "mu": 50,
       "sigma": 10
     }
   },
   {
     "name": "Bolton Wanderers",
-    "country": "England",
+    "country": "ENG",
     "location": "Bolton",
     "stadium": "University of Bolton Stadium",
     "stadium_capacity": 28723,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Austria",
-          "probability": 0.1
-        }
-      ],
       "mu": 62,
       "sigma": 29
     }
   },
   {
     "name": "Boston United",
-    "country": "England",
+    "country": "ENG",
     "location": "Boston",
     "stadium": "York Street",
     "stadium_capacity": 6643,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "Australia",
-          "probability": 0.08
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.08
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.08
-        }
-      ],
       "mu": 49,
       "sigma": 23
     }
   },
   {
     "name": "AFC Bournemouth",
-    "country": "England",
+    "country": "ENG",
     "location": "Bournemouth",
     "stadium": "Vitality Stadium",
     "stadium_capacity": 11700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.84
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.03
-        }
-      ],
       "mu": 72,
       "sigma": 30
     }
   },
   {
     "name": "Bradford City",
-    "country": "England",
+    "country": "ENG",
     "location": "Bradford",
     "stadium": "Valley Parade",
     "stadium_capacity": 25136,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Angola",
-          "probability": 0.09
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.09
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.09
-        }
-      ],
       "mu": 45,
       "sigma": 16
     }
   },
   {
     "name": "Brentford",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Brentford Community Stadium",
     "stadium_capacity": 17250,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Russia",
-          "probability": 0.22
-        }
-      ],
       "mu": 81,
       "sigma": 15
     }
   },
   {
     "name": "Brighton and Hove Albion",
-    "country": "England",
+    "country": "ENG",
     "location": "Brighton and Hove",
     "stadium": "AMEX Stadium",
     "stadium_capacity": 30750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.79
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.1
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.1
-        }
-      ],
       "mu": 65,
       "sigma": 25
     }
   },
   {
     "name": "Bristol City",
-    "country": "England",
+    "country": "ENG",
     "location": "Bristol",
     "stadium": "Ashton Gate",
     "stadium_capacity": 27000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.06
-        },
-        {
-          "name": "Greece",
-          "probability": 0.06
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.06
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        }
-      ],
       "mu": 85,
       "sigma": 30
     }
   },
   {
     "name": "Bristol Rovers",
-    "country": "England",
+    "country": "ENG",
     "location": "Bristol",
     "stadium": "The Memorial Stadium",
     "stadium_capacity": 12100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.73
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.27
-        }
-      ],
       "mu": 70,
       "sigma": 29
     }
   },
   {
     "name": "Burnley",
-    "country": "England",
+    "country": "ENG",
     "location": "Burnley",
     "stadium": "Turf Moor",
     "stadium_capacity": 22546,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 26
     }
   },
   {
     "name": "Bury",
-    "country": "England",
+    "country": "ENG",
     "location": "Bury",
     "stadium": "Gigg Lane",
     "stadium_capacity": 11840,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.06
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.06
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        }
-      ],
       "mu": 58,
       "sigma": 27
     }
   },
   {
     "name": "Cambridge United",
-    "country": "England",
+    "country": "ENG",
     "location": "Cambridge",
     "stadium": "Abbey Stadium",
     "stadium_capacity": 8127,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.18
-        }
-      ],
       "mu": 83,
       "sigma": 24
     }
   },
   {
     "name": "Carlisle United",
-    "country": "England",
+    "country": "ENG",
     "location": "Carlisle",
     "stadium": "Brunton Park",
     "stadium_capacity": 18202,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.07
-        },
-        {
-          "name": "Japan",
-          "probability": 0.07
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.07
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.07
-        }
-      ],
       "mu": 83,
       "sigma": 24
     }
   },
   {
     "name": "Charlton Athletic",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "The Valley",
     "stadium_capacity": 27111,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.18
-        }
-      ],
       "mu": 68,
       "sigma": 25
     }
   },
   {
     "name": "Chelsea",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Stamford Bridge",
     "stadium_capacity": 41837,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.03
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 34
     }
   },
   {
     "name": "Cheltenham Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Cheltenham",
     "stadium": "Whaddon Road",
     "stadium_capacity": 7408,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 5
     }
   },
   {
     "name": "Chesterfield",
-    "country": "England",
+    "country": "ENG",
     "location": "Chesterfield",
     "stadium": "Technique Stadium",
     "stadium_capacity": 10504,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        }
-      ],
       "mu": 85,
       "sigma": 25
     }
   },
   {
     "name": "Colchester United",
-    "country": "England",
+    "country": "ENG",
     "location": "Colchester",
     "stadium": "Colchester Community Stadium",
     "stadium_capacity": 10105,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.88
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.06
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        }
-      ],
       "mu": 73,
       "sigma": 7
     }
   },
   {
     "name": "Coventry City",
-    "country": "England",
+    "country": "ENG",
     "location": "Coventry",
     "stadium": "Ricoh Arena",
     "stadium_capacity": 32609,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.84
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.16
-        }
-      ],
       "mu": 79,
       "sigma": 19
     }
   },
   {
     "name": "Crewe Alexandra",
-    "country": "England",
+    "country": "ENG",
     "location": "Crewe",
     "stadium": "Gresty Road",
     "stadium_capacity": 10153,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.1
-        }
-      ],
       "mu": 48,
       "sigma": 26
     }
   },
   {
     "name": "Crystal Palace",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Selhurst Park",
     "stadium_capacity": 26255,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.07
-        },
-        {
-          "name": "France",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        }
-      ],
       "mu": 74,
       "sigma": 18
     }
   },
   {
     "name": "Darlington",
-    "country": "England",
+    "country": "ENG",
     "location": "Darlington",
     "stadium": "Blackwell Meadows",
     "stadium_capacity": 3300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.03
-        }
-      ],
       "mu": 48,
       "sigma": 8
     }
   },
   {
     "name": "Derby County",
-    "country": "England",
+    "country": "ENG",
     "location": "Derby",
     "stadium": "Pride Park",
     "stadium_capacity": 33597,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.19
-        }
-      ],
       "mu": 47,
       "sigma": 18
     }
   },
   {
     "name": "Doncaster Rovers",
-    "country": "England",
+    "country": "ENG",
     "location": "Doncaster",
     "stadium": "Keepmoat Stadium",
     "stadium_capacity": 15231,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.71
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.15
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.15
-        }
-      ],
       "mu": 49,
       "sigma": 16
     }
   },
   {
     "name": "Everton",
-    "country": "England",
+    "country": "ENG",
     "location": "Liverpool",
     "stadium": "Goodison Park",
     "stadium_capacity": 40157,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.06
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.06
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.06
-        },
-        {
-          "name": "Oman",
-          "probability": 0.06
-        }
-      ],
       "mu": 51,
       "sigma": 13
     }
   },
   {
     "name": "Fulham",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Craven Cottage",
     "stadium_capacity": 25700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.09
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.09
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.09
-        }
-      ],
       "mu": 55,
       "sigma": 26
     }
   },
   {
     "name": "Gillingham",
-    "country": "England",
+    "country": "ENG",
     "location": "Gillingham",
     "stadium": "Priestfield",
     "stadium_capacity": 11582,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.88
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.12
-        }
-      ],
       "mu": 59,
       "sigma": 30
     }
   },
   {
     "name": "Grimsby Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Cleethorpes",
     "stadium": "Blundell Park",
     "stadium_capacity": 10033,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Angola",
-          "probability": 0.1
-        }
-      ],
       "mu": 64,
       "sigma": 10
     }
   },
   {
     "name": "Hartlepool United",
-    "country": "England",
+    "country": "ENG",
     "location": "Hartlepool",
     "stadium": "Victoria Park",
     "stadium_capacity": 7787,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        }
-      ],
       "mu": 45,
       "sigma": 34
     }
   },
   {
     "name": "Huddersfield Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Huddersfield",
     "stadium": "John Smith's Stadium",
     "stadium_capacity": 24500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.09
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.09
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.09
-        }
-      ],
       "mu": 78,
       "sigma": 11
     }
   },
   {
     "name": "Hull City",
-    "country": "England",
+    "country": "ENG",
     "location": "Kingston upon Hull",
     "stadium": "KCOM Stadium",
     "stadium_capacity": 25586,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.79
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.07
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.07
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.07
-        }
-      ],
       "mu": 68,
       "sigma": 19
     }
   },
   {
     "name": "Ipswich Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Ipswich",
     "stadium": "Portman Road",
     "stadium_capacity": 30311,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 22
     }
   },
   {
     "name": "Kidderminster Harriers",
-    "country": "England",
+    "country": "ENG",
     "location": "Kidderminster",
     "stadium": "Aggborough",
     "stadium_capacity": 6238,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 28
     }
   },
   {
     "name": "Leicester City",
-    "country": "England",
+    "country": "ENG",
     "location": "Leicester",
     "stadium": "King Power Stadium",
     "stadium_capacity": 32262,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.08
-        },
-        {
-          "name": "Italy",
-          "probability": 0.08
-        }
-      ],
       "mu": 69,
       "sigma": 10
     }
   },
   {
     "name": "Leyton Orient",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Brisbane Road",
     "stadium_capacity": 9271,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.08
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.08
-        }
-      ],
       "mu": 81,
       "sigma": 19
     }
   },
   {
     "name": "Lincoln City",
-    "country": "England",
+    "country": "ENG",
     "location": "Lincoln",
     "stadium": "Sincil Bank",
     "stadium_capacity": 10127,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.71
-        },
-        {
-          "name": "France",
-          "probability": 0.15
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.15
-        }
-      ],
       "mu": 79,
       "sigma": 5
     }
   },
   {
     "name": "Liverpool",
-    "country": "England",
+    "country": "ENG",
     "location": "Liverpool",
     "stadium": "Anfield",
     "stadium_capacity": 54167,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.71
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.15
-        },
-        {
-          "name": "Japan",
-          "probability": 0.15
-        }
-      ],
       "mu": 78,
       "sigma": 23
     }
   },
   {
     "name": "Luton Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Luton",
     "stadium": "Kenilworth Road",
     "stadium_capacity": 10260,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Austria",
-          "probability": 0.07
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Spain",
-          "probability": 0.07
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        }
-      ],
       "mu": 80,
       "sigma": 24
     }
   },
   {
     "name": "Macclesfield FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Macclesfield",
     "stadium": "Moss Rose",
     "stadium_capacity": 6335,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.71
-        },
-        {
-          "name": "Chile",
-          "probability": 0.1
-        },
-        {
-          "name": "Panama",
-          "probability": 0.1
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.1
-        }
-      ],
       "mu": 68,
       "sigma": 16
     }
   },
   {
     "name": "Manchester City",
-    "country": "England",
+    "country": "ENG",
     "location": "Manchester",
     "stadium": "Etihad Stadium",
     "stadium_capacity": 55097,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.76
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        }
-      ],
       "mu": 48,
       "sigma": 29
     }
   },
   {
     "name": "Mansfield Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Mansfield",
     "stadium": "Field Mill",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.09
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.09
-        }
-      ],
       "mu": 77,
       "sigma": 28
     }
   },
   {
     "name": "Manchester United",
-    "country": "England",
+    "country": "ENG",
     "location": "Manchester",
     "stadium": "Old Trafford",
     "stadium_capacity": 75765,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.07
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.07
-        }
-      ],
       "mu": 52,
       "sigma": 23
     }
   },
   {
     "name": "Middlesbrough",
-    "country": "England",
+    "country": "ENG",
     "location": "Middlesbrough",
     "stadium": "Riverside Stadium",
     "stadium_capacity": 34988,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.11
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.11
-        }
-      ],
       "mu": 79,
       "sigma": 8
     }
   },
   {
     "name": "Millwall",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "The Den",
     "stadium_capacity": 20146,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.76
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.24
-        }
-      ],
       "mu": 56,
       "sigma": 14
     }
   },
   {
     "name": "Northampton Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Northampton",
     "stadium": "Sixfields Stadium",
     "stadium_capacity": 7653,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.84
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        }
-      ],
       "mu": 63,
       "sigma": 29
     }
   },
   {
     "name": "Norwich City",
-    "country": "England",
+    "country": "ENG",
     "location": "Norwich",
     "stadium": "Carrow Road",
     "stadium_capacity": 27250,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.88
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        }
-      ],
       "mu": 49,
       "sigma": 21
     }
   },
   {
     "name": "Nottingham Forest",
-    "country": "England",
+    "country": "ENG",
     "location": "Nottingham",
     "stadium": "The City Ground",
     "stadium_capacity": 31250,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.04
-        }
-      ],
       "mu": 69,
       "sigma": 30
     }
   },
   {
     "name": "Notts County",
-    "country": "England",
+    "country": "ENG",
     "location": "Nottingham",
     "stadium": "Meadow Lane",
     "stadium_capacity": 20229,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 26
     }
   },
   {
     "name": "Oldham Athletic",
-    "country": "England",
+    "country": "ENG",
     "location": "Oldham",
     "stadium": "Boundary Park",
     "stadium_capacity": 13512,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.79
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.04
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 11
     }
   },
   {
     "name": "Oxford United",
-    "country": "England",
+    "country": "ENG",
     "location": "Oxford",
     "stadium": "Kassam Stadium",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Oman",
-          "probability": 0.28
-        }
-      ],
       "mu": 53,
       "sigma": 27
     }
   },
   {
     "name": "Peterborough United",
-    "country": "England",
+    "country": "ENG",
     "location": "Peterborough",
     "stadium": "London Road Stadium",
     "stadium_capacity": 15315,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.71
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.1
-        },
-        {
-          "name": "Macao",
-          "probability": 0.1
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.1
-        }
-      ],
       "mu": 62,
       "sigma": 21
     }
   },
   {
     "name": "Plymouth Argyle",
-    "country": "England",
+    "country": "ENG",
     "location": "Plymouth",
     "stadium": "Home Park",
     "stadium_capacity": 19500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.28
-        }
-      ],
       "mu": 63,
       "sigma": 24
     }
   },
   {
     "name": "Preston North End",
-    "country": "England",
+    "country": "ENG",
     "location": "Preston",
     "stadium": "Deepdale",
     "stadium_capacity": 23408,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.18
-        }
-      ],
       "mu": 83,
       "sigma": 8
     }
   },
   {
     "name": "Portsmouth",
-    "country": "England",
+    "country": "ENG",
     "location": "Portsmouth",
     "stadium": "Fratton Park",
     "stadium_capacity": 21100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Greece",
-          "probability": 0.25
-        }
-      ],
       "mu": 49,
       "sigma": 19
     }
   },
   {
     "name": "Port Vale",
-    "country": "England",
+    "country": "ENG",
     "location": "Stoke-on-Trent",
     "stadium": "Vale Park",
     "stadium_capacity": 22356,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.05
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 27
     }
   },
   {
     "name": "Queens Park Rangers",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Loftus Road",
     "stadium_capacity": 18439,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.17
-        }
-      ],
       "mu": 52,
       "sigma": 8
     }
   },
   {
     "name": "Reading",
-    "country": "England",
+    "country": "ENG",
     "location": "Reading",
     "stadium": "Madejski",
     "stadium_capacity": 24161,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.11
-        },
-        {
-          "name": "Macao",
-          "probability": 0.11
-        }
-      ],
       "mu": 75,
       "sigma": 16
     }
   },
   {
     "name": "Rochdale",
-    "country": "England",
+    "country": "ENG",
     "location": "Rochdale",
     "stadium": "Spotland",
     "stadium_capacity": 10249,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.73
-        },
-        {
-          "name": "Angola",
-          "probability": 0.27
-        }
-      ],
       "mu": 47,
       "sigma": 6
     }
   },
   {
     "name": "Rotherham United",
-    "country": "England",
+    "country": "ENG",
     "location": "Rotherham",
     "stadium": "New York Stadium",
     "stadium_capacity": 12021,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.07
-        },
-        {
-          "name": "Romania",
-          "probability": 0.07
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        }
-      ],
       "mu": 49,
       "sigma": 27
     }
   },
   {
     "name": "Rushden & Diamonds",
-    "country": "England",
+    "country": "ENG",
     "location": "Irthlingborough",
     "stadium": "Nene Park",
     "stadium_capacity": 6441,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        },
-        {
-          "name": "Austria",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 19
     }
   },
   {
     "name": "Scunthorpe United",
-    "country": "England",
+    "country": "ENG",
     "location": "Scunthorpe",
     "stadium": "Glanford Park",
     "stadium_capacity": 9088,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Norway",
-          "probability": 0.11
-        }
-      ],
       "mu": 77,
       "sigma": 15
     }
   },
   {
     "name": "Sheffield United",
-    "country": "England",
+    "country": "ENG",
     "location": "Sheffield",
     "stadium": "Bramall Lane",
     "stadium_capacity": 32609,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.07
-        },
-        {
-          "name": "Panama",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 21
     }
   },
   {
     "name": "Sheffield Wednesday",
-    "country": "England",
+    "country": "ENG",
     "location": "Sheffield",
     "stadium": "Hillsborough",
     "stadium_capacity": 39814,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Angola",
-          "probability": 0.09
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.09
-        }
-      ],
       "mu": 83,
       "sigma": 32
     }
   },
   {
     "name": "Southampton",
-    "country": "England",
+    "country": "ENG",
     "location": "Southampton",
     "stadium": "St Mary's Stadium",
     "stadium_capacity": 32689,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.02
-        },
-        {
-          "name": "Panama",
-          "probability": 0.02
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.02
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 28
     }
   },
   {
     "name": "Southend United",
-    "country": "England",
+    "country": "ENG",
     "location": "Southend-on-Sea",
     "stadium": "Roots Hall",
     "stadium_capacity": 12392,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.88
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 10
     }
   },
   {
     "name": "Stockport County",
-    "country": "England",
+    "country": "ENG",
     "location": "Stockport",
     "stadium": "Edgeley Park",
     "stadium_capacity": 10841,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 29
     }
   },
   {
     "name": "Stoke City",
-    "country": "England",
+    "country": "ENG",
     "location": "Stoke-on-Trent",
     "stadium": "Britannia Stadium",
     "stadium_capacity": 28384,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 18
     }
   },
   {
     "name": "Swindon Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Swindon",
     "stadium": "County Ground",
     "stadium_capacity": 14700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.02
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.02
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.02
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.02
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.02
-        }
-      ],
       "mu": 53,
       "sigma": 16
     }
   },
   {
     "name": "Torquay United",
-    "country": "England",
+    "country": "ENG",
     "location": "Torquay",
     "stadium": "Plainmoor",
     "stadium_capacity": 6200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.06
-        },
-        {
-          "name": "Greece",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.06
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 22
     }
   },
   {
     "name": "Tottenham Hotspur",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Tottenham Hotspur Stadium",
     "stadium_capacity": 62062,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Italy",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        }
-      ],
       "mu": 63,
       "sigma": 29
     }
   },
   {
     "name": "Tranmere Rovers",
-    "country": "England",
+    "country": "ENG",
     "location": "Birkenhead",
     "stadium": "Prenton Park",
     "stadium_capacity": 16567,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.05
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 22
     }
   },
   {
     "name": "Walsall",
-    "country": "England",
+    "country": "ENG",
     "location": "Walsall",
     "stadium": "Banks's Stadium",
     "stadium_capacity": 11300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 21
     }
   },
   {
     "name": "Watford",
-    "country": "England",
+    "country": "ENG",
     "location": "Watford",
     "stadium": "Vicarage Road",
     "stadium_capacity": 21438,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.84
-        },
-        {
-          "name": "Canada",
-          "probability": 0.08
-        },
-        {
-          "name": "Macao",
-          "probability": 0.08
-        }
-      ],
       "mu": 66,
       "sigma": 14
     }
   },
   {
     "name": "West Bromwich Albion",
-    "country": "England",
+    "country": "ENG",
     "location": "West Bromwich",
     "stadium": "The Hawthorns",
     "stadium_capacity": 26272,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Wales",
-          "probability": 0.08
-        },
-        {
-          "name": "Peru",
-          "probability": 0.08
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.08
-        }
-      ],
       "mu": 46,
       "sigma": 18
     }
   },
   {
     "name": "West Ham United",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Olympic Stadium",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.03
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 12
     }
   },
   {
     "name": "Wigan Athletic",
-    "country": "England",
+    "country": "ENG",
     "location": "Wigan",
     "stadium": "DW Stadium",
     "stadium_capacity": 25138,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Russia",
-          "probability": 0.02
-        },
-        {
-          "name": "India",
-          "probability": 0.02
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.02
-        },
-        {
-          "name": "China",
-          "probability": 0.02
-        }
-      ],
       "mu": 63,
       "sigma": 31
     }
   },
   {
     "name": "Milton Keynes Dons",
-    "country": "England",
+    "country": "ENG",
     "location": "Milton Keynes",
     "stadium": "Stadium MK",
     "stadium_capacity": 30500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "India",
-          "probability": 0.11
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.11
-        }
-      ],
       "mu": 51,
       "sigma": 17
     }
   },
   {
     "name": "Wolverhampton Wanderers",
-    "country": "England",
+    "country": "ENG",
     "location": "Wolverhampton",
     "stadium": "Molineux",
     "stadium_capacity": 31700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.02
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.02
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.02
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 15
     }
   },
   {
     "name": "Wycombe Wanderers",
-    "country": "England",
+    "country": "ENG",
     "location": "High Wycombe",
     "stadium": "Adams Park",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.77
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.08
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.08
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.08
-        }
-      ],
       "mu": 82,
       "sigma": 28
     }
   },
   {
     "name": "Yeovil Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Yeovil",
     "stadium": "Huish Park",
     "stadium_capacity": 9565,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 7
     }
   },
   {
     "name": "York City",
-    "country": "England",
+    "country": "ENG",
     "location": "York",
     "stadium": "York Community Stadium",
     "stadium_capacity": 8005,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.05
-        },
-        {
-          "name": "Malta",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 15
     }
   },
   {
     "name": "Shrewsbury Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Shrewsbury",
     "stadium": "New Meadow",
     "stadium_capacity": 9875,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.04
-        }
-      ],
       "mu": 83,
       "sigma": 27
     }
   },
   {
     "name": "Accrington Stanley",
-    "country": "England",
+    "country": "ENG",
     "location": "Accrington",
     "stadium": "Wham Stadium",
     "stadium_capacity": 5450,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 20
     }
   },
   {
     "name": "Barnet",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "The Hive Stadium",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Spain",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 22
     }
   },
   {
     "name": "Burton Albion",
-    "country": "England",
+    "country": "ENG",
     "location": "Burton upon Trent",
     "stadium": "Pirelli Stadium",
     "stadium_capacity": 6912,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.05
-        },
-        {
-          "name": "Peru",
-          "probability": 0.05
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        }
-      ],
       "mu": 46,
       "sigma": 35
     }
   },
   {
     "name": "Grays Athletic",
-    "country": "England",
+    "country": "ENG",
     "location": "Grays",
     "stadium": "Rookery Hill",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.86
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        }
-      ],
       "mu": 69,
       "sigma": 31
     }
   },
   {
     "name": "Exeter City",
-    "country": "England",
+    "country": "ENG",
     "location": "Exeter",
     "stadium": "St James Park",
     "stadium_capacity": 9036,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.06
-        },
-        {
-          "name": "Oman",
-          "probability": 0.06
-        }
-      ],
       "mu": 57,
       "sigma": 34
     }
   },
   {
     "name": "Morecambe",
-    "country": "England",
+    "country": "ENG",
     "location": "Morecambe",
     "stadium": "Globe Arena",
     "stadium_capacity": 6402,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 26
     }
   },
   {
     "name": "Farsley Celtic",
-    "country": "England",
+    "country": "ENG",
     "location": "Farsley",
     "stadium": "Throstle Nest",
     "stadium_capacity": 3900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.28
-        }
-      ],
       "mu": 69,
       "sigma": 6
     }
   },
   {
     "name": "Barrow AFC",
-    "country": "England",
+    "country": "ENG",
     "location": "Barrow",
     "stadium": "Holker Street",
     "stadium_capacity": 5045,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.86
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.07
-        },
-        {
-          "name": "Russia",
-          "probability": 0.07
-        }
-      ],
       "mu": 81,
       "sigma": 17
     }
   },
   {
     "name": "AFC Wimbledon",
-    "country": "England",
+    "country": "ENG",
     "location": "Kingston upon Thames",
     "stadium": "Plough Lane",
     "stadium_capacity": 9300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.28
-        }
-      ],
       "mu": 59,
       "sigma": 24
     }
   },
   {
     "name": "Gateshead",
-    "country": "England",
+    "country": "ENG",
     "location": "Gateshead",
     "stadium": "Gateshead International Stadium",
     "stadium_capacity": 11800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 22
     }
   },
   {
     "name": "Hyde United",
-    "country": "England",
+    "country": "ENG",
     "location": "Hyde",
     "stadium": "Ewen Fields",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.19
-        }
-      ],
       "mu": 49,
       "sigma": 30
     }
   },
   {
     "name": "Bradford Park Avenue",
-    "country": "England",
+    "country": "ENG",
     "location": "Bradford",
     "stadium": "Horsfall Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Austria",
-          "probability": 0.12
-        },
-        {
-          "name": "Poland",
-          "probability": 0.12
-        }
-      ],
       "mu": 49,
       "sigma": 7
     }
   },
   {
     "name": "Worcester City",
-    "country": "England",
+    "country": "ENG",
     "location": "Worcester",
     "stadium": "Aggborough",
     "stadium_capacity": 6238,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.06
-        },
-        {
-          "name": "Albania",
-          "probability": 0.06
-        },
-        {
-          "name": "Wales",
-          "probability": 0.06
-        }
-      ],
       "mu": 47,
       "sigma": 21
     }
   },
   {
     "name": "Gainsborough Trinity",
-    "country": "England",
+    "country": "ENG",
     "location": "Gainsborough",
     "stadium": "The Northolme",
     "stadium_capacity": 4304,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 34
     }
   },
   {
     "name": "Oxford City",
-    "country": "England",
+    "country": "ENG",
     "location": "Marston",
     "stadium": "Marsh Lane",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.09
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.09
-        }
-      ],
       "mu": 78,
       "sigma": 11
     }
   },
   {
     "name": "Gosport Borough",
-    "country": "England",
+    "country": "ENG",
     "location": "Gosport",
     "stadium": "Privett Park",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.76
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.05
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "Hemel Hempstead Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Hemel Hempstead",
     "stadium": "Vauxhall Road",
     "stadium_capacity": 3152,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.81
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.06
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        }
-      ],
       "mu": 63,
       "sigma": 33
     }
   },
   {
     "name": "Halesowen Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Halesowen",
     "stadium": "The Grove",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.25
-        }
-      ],
       "mu": 60,
       "sigma": 21
     }
   },
   {
     "name": "Ashton United",
-    "country": "England",
+    "country": "ENG",
     "location": "Ashton-under-Lyne",
     "stadium": "Hurst Cross",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.05
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        },
-        {
-          "name": "Spain",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 21
     }
   },
   {
     "name": "Skelmersdale United",
-    "country": "England",
+    "country": "ENG",
     "location": "Skelmersdale",
     "stadium": "West Lancashire College Stadium",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.11
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.11
-        }
-      ],
       "mu": 58,
       "sigma": 28
     }
   },
   {
     "name": "Stourbridge FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Stourbridge",
     "stadium": "War Memorial Athletic Ground",
     "stadium_capacity": 3067,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.86
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 28
     }
   },
   {
     "name": "Hampton & Richmond Borough",
-    "country": "England",
+    "country": "ENG",
     "location": "London",
     "stadium": "Beveree Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        }
-      ],
       "mu": 73,
       "sigma": 24
     }
   },
   {
     "name": "St Neots Town",
-    "country": "England",
+    "country": "ENG",
     "location": "St Neots",
     "stadium": "Rowley Park",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "China",
-          "probability": 0.18
-        }
-      ],
       "mu": 83,
       "sigma": 27
     }
   },
   {
     "name": "Warrington Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Warrington",
     "stadium": "Cantilever Park",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.8
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 26
     }
   },
   {
     "name": "Kendal Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Kendal",
     "stadium": "The Northgate Vehicle Hire Stadium",
     "stadium_capacity": 2400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 19
     }
   },
   {
     "name": "Whitley Bay",
-    "country": "England",
+    "country": "ENG",
     "location": "Whitley Bay",
     "stadium": "Hillheads Park",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Australia",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 13
     }
   },
   {
     "name": "Morpeth Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Morpeth",
     "stadium": "Craik Park",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        },
-        {
-          "name": "Finland",
-          "probability": 0.05
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Poland",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 27
     }
   },
   {
     "name": "East Thurrock United",
-    "country": "England",
+    "country": "ENG",
     "location": "Corringham",
     "stadium": "Rookery Hill",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.72
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.06
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.06
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.06
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        }
-      ],
       "mu": 61,
       "sigma": 32
     }
   },
   {
     "name": "Ilkeston Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Ilkeston",
     "stadium": "New Manor Ground",
     "stadium_capacity": 3029,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        }
-      ],
       "mu": 64,
       "sigma": 32
     }
   },
   {
     "name": "Spennymoor Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Spennymoor",
     "stadium": "The Brewery Field",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.08
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.08
-        }
-      ],
       "mu": 49,
       "sigma": 8
     }
   },
   {
     "name": "Tadcaster Albion",
-    "country": "England",
+    "country": "ENG",
     "location": "Tadcaster",
     "stadium": "i2i Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.86
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        }
-      ],
       "mu": 67,
       "sigma": 29
     }
   },
   {
     "name": "Cleethorpes Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Grimsby",
     "stadium": "The Bradley Football Development Centre",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.11
-        }
-      ],
       "mu": 59,
       "sigma": 25
     }
   },
   {
     "name": "Merstham FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Merstham",
     "stadium": "Moatside",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.04
-        },
-        {
-          "name": "Panama",
-          "probability": 0.04
-        }
-      ],
       "mu": 66,
       "sigma": 15
     }
   },
   {
     "name": "Heybridge Swifts",
-    "country": "England",
+    "country": "ENG",
     "location": "Heybridge",
     "stadium": "Scraley Road",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.05
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 11
     }
   },
   {
     "name": "Stratford Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Stratford-upon-Avon",
     "stadium": "MoodChimp Stadium",
     "stadium_capacity": 1400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.9
-        },
-        {
-          "name": "Peru",
-          "probability": 0.02
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.02
-        },
-        {
-          "name": "France",
-          "probability": 0.02
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.02
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.02
-        }
-      ],
       "mu": 68,
       "sigma": 16
     }
   },
   {
     "name": "Nantwich Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Nantwich",
     "stadium": "Weaver Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Japan",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 19
     }
   },
   {
     "name": "Sutton Coldfield Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Sutton Coldfield",
     "stadium": "Central Ground",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.86
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.03
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.03
-        }
-      ],
       "mu": 47,
       "sigma": 14
     }
   },
   {
     "name": "Maldon & Tiptree",
-    "country": "England",
+    "country": "ENG",
     "location": "Maldon",
     "stadium": "Wallace Binder Ground",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.08
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.08
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.08
-        }
-      ],
       "mu": 77,
       "sigma": 28
     }
   },
   {
     "name": "Leatherhead FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Leatherhead",
     "stadium": "Fetcham Grove",
     "stadium_capacity": 3400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.75
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.06
-        },
-        {
-          "name": "Togo",
-          "probability": 0.06
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.06
-        },
-        {
-          "name": "Laos",
-          "probability": 0.06
-        }
-      ],
       "mu": 49,
       "sigma": 27
     }
   },
   {
     "name": "Winchester City",
-    "country": "England",
+    "country": "ENG",
     "location": "Winchester",
     "stadium": "The City Ground",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.13
-        }
-      ],
       "mu": 60,
       "sigma": 18
     }
   },
   {
     "name": "Barwell FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Barwell",
     "stadium": "Kirkby Road",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.87
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.13
-        }
-      ],
       "mu": 75,
       "sigma": 27
     }
   },
   {
     "name": "Alvechurch",
-    "country": "England",
+    "country": "ENG",
     "location": "Alvechurch",
     "stadium": "Lye Meadow",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.82
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.09
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.09
-        }
-      ],
       "mu": 69,
       "sigma": 22
     }
   },
   {
     "name": "Whickham",
-    "country": "England",
+    "country": "ENG",
     "location": "Whickham",
     "stadium": "The Glebe Sports Ground",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.85
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.03
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        }
-      ],
       "mu": 68,
       "sigma": 22
     }
   },
   {
     "name": "Atherton Collieries",
-    "country": "England",
+    "country": "ENG",
     "location": "Atherton",
     "stadium": "Alder House",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.03
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.03
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Canada",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 15
     }
   },
   {
     "name": "Glossop North End",
-    "country": "England",
+    "country": "ENG",
     "location": "Glossop",
     "stadium": "Arthur Goldthorpe Stadium",
     "stadium_capacity": 1350,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.78
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.07
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.07
-        }
-      ],
       "mu": 49,
       "sigma": 5
     }
   },
   {
     "name": "Highworth Town",
-    "country": "England",
+    "country": "ENG",
     "location": "Highworth",
     "stadium": "The Elms Recreation Ground",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.74
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.13
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.13
-        }
-      ],
       "mu": 48,
       "sigma": 29
     }
   },
   {
     "name": "Trafford FC",
-    "country": "England",
+    "country": "ENG",
     "location": "Flixton",
     "stadium": "Shawe View",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.83
-        },
-        {
-          "name": "Spain",
-          "probability": 0.06
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.06
-        },
-        {
-          "name": "Angola",
-          "probability": 0.06
-        }
-      ],
       "mu": 73,
       "sigma": 34
     }
   },
   {
     "name": "Stocksbridge Park Steels",
-    "country": "England",
+    "country": "ENG",
     "location": "Stocksbridge",
     "stadium": "Bracken Moor",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "England",
-          "probability": 0.89
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 18
     }
   },
   {
     "name": "Deportivo Mongomo",
-    "country": "Equatorial Guinea",
+    "country": "EQG",
     "location": "Mongomo",
     "stadium": "Estadio La Libertad",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.79
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.21
-        }
-      ],
       "mu": 68,
       "sigma": 33
     }
   },
   {
     "name": "Flora",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Tallinn",
     "stadium": "A.Le Coq Arena",
     "stadium_capacity": 9300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.77
-        },
-        {
-          "name": "Romania",
-          "probability": 0.23
-        }
-      ],
       "mu": 48,
       "sigma": 20
     }
   },
   {
     "name": "Ajax Lasnam\\u00e4e",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Tallinn",
     "stadium": "Ajax staadion",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.83
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "Spain",
-          "probability": 0.06
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.06
-        }
-      ],
       "mu": 56,
       "sigma": 19
     }
   },
   {
     "name": "Kuressaare",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Kuressaare",
     "stadium": "Kuressaare linnastaadion",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.76
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.08
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.08
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.08
-        }
-      ],
       "mu": 83,
       "sigma": 26
     }
   },
   {
     "name": "N\\u00f5mme Kalju",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Tallinn",
     "stadium": "Kadrioru",
     "stadium_capacity": 4750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.73
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.07
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.07
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.07
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.07
-        }
-      ],
       "mu": 77,
       "sigma": 6
     }
   },
   {
     "name": "Paide Linnameeskond",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Linnameeskond",
     "stadium": "P\\u00dcG Stadium",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.87
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.04
-        }
-      ],
       "mu": 73,
       "sigma": 16
     }
   },
   {
     "name": "FCI Tallinn",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Tallinn",
     "stadium": "Lasnam\\u00e4e KJH",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.8
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 16
     }
   },
   {
     "name": "J\\u00f5hvi FC Lokomotiv",
-    "country": "Estonia",
+    "country": "EST",
     "location": "J\\u00f5hvi",
     "stadium": "J\\u00f5hvi linnastaadion",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.85
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 33
     }
   },
   {
     "name": "Kivioli Irbis",
-    "country": "Estonia",
+    "country": "EST",
     "location": "Kivi\\u00f5li",
     "stadium": "Kivi\\u00f5li Stadium",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Estonia",
-          "probability": 0.72
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.14
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.14
-        }
-      ],
       "mu": 58,
       "sigma": 34
     }
   },
   {
     "name": "Mekelle Kenema",
-    "country": "Ethiopia",
+    "country": "ETH",
     "location": "Mekelle",
     "stadium": "Mekelle Stadium",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ethiopia",
-          "probability": 0.73
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 5
     }
   },
   {
     "name": "Shire Endaselassie",
-    "country": "Ethiopia",
+    "country": "ETH",
     "location": "Shire",
     "stadium": "Endaselassie Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ethiopia",
-          "probability": 0.82
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        }
-      ],
       "mu": 64,
       "sigma": 18
     }
   },
   {
     "name": "Ethiopian Coffee SC",
-    "country": "Ethiopia",
+    "country": "ETH",
     "location": "Addis Ababa",
     "stadium": "Addis Ababa Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ethiopia",
-          "probability": 0.88
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.12
-        }
-      ],
       "mu": 82,
       "sigma": 28
     }
   },
   {
     "name": "K\\u00cd Klaksv\\u00edk",
-    "country": "Faroe Islands",
+    "country": "FRO",
     "location": "Klaksvik",
     "stadium": "Djupumyra Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Faroe Islands",
-          "probability": 0.71
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.15
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.15
-        }
-      ],
       "mu": 81,
       "sigma": 24
     }
   },
   {
     "name": "Argja B\\u00f3ltfelag",
-    "country": "Faroe Islands",
+    "country": "FRO",
     "location": "Argir",
     "stadium": "Argir Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Faroe Islands",
-          "probability": 0.89
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.05
-        }
-      ],
       "mu": 68,
       "sigma": 21
     }
   },
   {
     "name": "FC Suduroy",
-    "country": "Faroe Islands",
+    "country": "FRO",
     "location": "V\\u00e1gur",
     "stadium": "Vesturi \\u00e1 Ei\\u00f0inum Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Faroe Islands",
-          "probability": 0.75
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        }
-      ],
       "mu": 54,
       "sigma": 17
     }
   },
   {
     "name": "TB Tvoroyri",
-    "country": "Faroe Islands",
+    "country": "FRO",
     "location": "Tv\\u00f8royri",
     "stadium": "Vi\\u00f0 St\\u00f3r\\u00e1 Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Faroe Islands",
-          "probability": 0.89
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 8
     }
   },
   {
     "name": "07 Vestur",
-    "country": "Faroe Islands",
+    "country": "FRO",
     "location": "S\\u00f8rv\\u00e1gur",
     "stadium": "\\u00e1 Dungasandi",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Faroe Islands",
-          "probability": 0.78
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 23
     }
   },
   {
     "name": "Tampere United",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Tampere",
     "stadium": "Ratina Stadion",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.83
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.17
-        }
-      ],
       "mu": 80,
       "sigma": 22
     }
   },
   {
     "name": "FC Lahti",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Lahti",
     "stadium": "Lahden Stadion",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.78
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        }
-      ],
       "mu": 69,
       "sigma": 32
     }
   },
   {
     "name": "TPS",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Turku",
     "stadium": "Veritas",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.85
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        }
-      ],
       "mu": 77,
       "sigma": 34
     }
   },
   {
     "name": "AC Oulu",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Oulu",
     "stadium": "Castren",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.75
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.25
-        }
-      ],
       "mu": 63,
       "sigma": 30
     }
   },
   {
     "name": "RoPS",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Rovaniemi",
     "stadium": "Keskuskentt\\u00e4",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.88
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.02
-        },
-        {
-          "name": "Greece",
-          "probability": 0.02
-        },
-        {
-          "name": "Angola",
-          "probability": 0.02
-        },
-        {
-          "name": "China",
-          "probability": 0.02
-        },
-        {
-          "name": "Canada",
-          "probability": 0.02
-        }
-      ],
       "mu": 84,
       "sigma": 12
     }
   },
   {
     "name": "JIPPO",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Joensuu",
     "stadium": "Keskuskentt\\u00e4",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.78
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Wales",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        }
-      ],
       "mu": 53,
       "sigma": 9
     }
   },
   {
     "name": "FC Jazz",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Pori",
     "stadium": "Pori Stadium",
     "stadium_capacity": 12300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.84
-        },
-        {
-          "name": "Albania",
-          "probability": 0.08
-        },
-        {
-          "name": "China",
-          "probability": 0.08
-        }
-      ],
       "mu": 65,
       "sigma": 21
     }
   },
   {
     "name": "HIFK",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Helsinki",
     "stadium": "T\\u00f6\\u00f6l\\u00f6n Pallokentt\\u00e4",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.83
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.03
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Chile",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        }
-      ],
       "mu": 63,
       "sigma": 33
     }
   },
   {
     "name": "FC Ilves",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Tampere",
     "stadium": "Tammela Stadion",
     "stadium_capacity": 5040,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.8
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.1
-        },
-        {
-          "name": "India",
-          "probability": 0.1
-        }
-      ],
       "mu": 52,
       "sigma": 27
     }
   },
   {
     "name": "JS Hercules",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Oulu",
     "stadium": "Hein\\u00e4p\\u00e4\\u00e4",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.87
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.07
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 9
     }
   },
   {
     "name": "Grankulla IFK",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Kauniainen",
     "stadium": "Kauniaisten Keskuskentt\\u00e4",
     "stadium_capacity": 700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.81
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.09
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.09
-        }
-      ],
       "mu": 73,
       "sigma": 5
     }
   },
   {
     "name": "Kokkolan Palloveikot",
-    "country": "Finland",
+    "country": "FIN",
     "location": "Kokkola",
     "stadium": "Kokkolan Keskuskentt\\u00e4",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Finland",
-          "probability": 0.74
-        },
-        {
-          "name": "China",
-          "probability": 0.13
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.13
-        }
-      ],
       "mu": 69,
       "sigma": 18
     }
   },
   {
     "name": "US Cr\\u00e9teil",
-    "country": "France",
+    "country": "FRA",
     "location": "Cr\\u00e9teil",
     "stadium": "Dominique-Duvauchelle",
     "stadium_capacity": 12150,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.78
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        },
-        {
-          "name": "Austria",
-          "probability": 0.04
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Laos",
-          "probability": 0.04
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 8
     }
   },
   {
     "name": "FC Gueugnon",
-    "country": "France",
+    "country": "FRA",
     "location": "Gueugnon",
     "stadium": "Jean-Laville",
     "stadium_capacity": 13800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.81
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 11
     }
   },
   {
     "name": "Stade Lavallois",
-    "country": "France",
+    "country": "FRA",
     "location": "Laval",
     "stadium": "Francis Le Basser",
     "stadium_capacity": 18739,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.82
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.18
-        }
-      ],
       "mu": 67,
       "sigma": 26
     }
   },
   {
     "name": "Le Havre AC",
-    "country": "France",
+    "country": "FRA",
     "location": "Le Havre",
     "stadium": "Stade Oc\\u00e9ane",
     "stadium_capacity": 25178,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.79
-        },
-        {
-          "name": "Iran",
-          "probability": 0.21
-        }
-      ],
       "mu": 71,
       "sigma": 34
     }
   },
   {
     "name": "Chamois Niortais",
-    "country": "France",
+    "country": "FRA",
     "location": "Niort",
     "stadium": "Ren\\u00e9-Gaillard",
     "stadium_capacity": 10988,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.82
-        },
-        {
-          "name": "Canada",
-          "probability": 0.09
-        },
-        {
-          "name": "Togo",
-          "probability": 0.09
-        }
-      ],
       "mu": 45,
       "sigma": 33
     }
   },
   {
     "name": "Paris Saint-Germain",
-    "country": "France",
+    "country": "FRA",
     "location": "Paris",
     "stadium": "Parc des Princes",
     "stadium_capacity": 48712,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.72
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        },
-        {
-          "name": "England",
-          "probability": 0.07
-        },
-        {
-          "name": "Canada",
-          "probability": 0.07
-        },
-        {
-          "name": "Greece",
-          "probability": 0.07
-        }
-      ],
       "mu": 49,
       "sigma": 18
     }
   },
   {
     "name": "Vannes OC",
-    "country": "France",
+    "country": "FRA",
     "location": "Vannes",
     "stadium": "Stade de la Rabine",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.79
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.07
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.07
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.07
-        }
-      ],
       "mu": 57,
       "sigma": 7
     }
   },
   {
     "name": "FC Rouen",
-    "country": "France",
+    "country": "FRA",
     "location": "Rouen",
     "stadium": "Robert Diochon",
     "stadium_capacity": 11300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.82
-        },
-        {
-          "name": "Iran",
-          "probability": 0.06
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.06
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.06
-        }
-      ],
       "mu": 73,
       "sigma": 6
     }
   },
   {
     "name": "AS Beauvais Oise",
-    "country": "France",
+    "country": "FRA",
     "location": "Beauvais",
     "stadium": "Pierre Brisson",
     "stadium_capacity": 10178,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.83
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.17
-        }
-      ],
       "mu": 55,
       "sigma": 27
     }
   },
   {
     "name": "SAS \\u00c9pinal",
-    "country": "France",
+    "country": "FRA",
     "location": "Epinal",
     "stadium": "Colombi\\u00e8re",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.83
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.03
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        }
-      ],
       "mu": 58,
       "sigma": 33
     }
   },
   {
     "name": "Gaz\\u00e9lec Ajaccio",
-    "country": "France",
+    "country": "FRA",
     "location": "Ajaccio",
     "stadium": "Ange Casanova",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.88
-        },
-        {
-          "name": "Germany",
-          "probability": 0.06
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.06
-        }
-      ],
       "mu": 72,
       "sigma": 34
     }
   },
   {
     "name": "SR Colmar",
-    "country": "France",
+    "country": "FRA",
     "location": "Colmar",
     "stadium": "Colmar",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.86
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.14
-        }
-      ],
       "mu": 70,
       "sigma": 19
     }
   },
   {
     "name": "Luzenac AP",
-    "country": "France",
+    "country": "FRA",
     "location": "Luzenac",
     "stadium": "Stade Paul F\\u00e9dou",
     "stadium_capacity": 1600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.72
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.28
-        }
-      ],
       "mu": 55,
       "sigma": 10
     }
   },
   {
     "name": "CA Bastia",
-    "country": "France",
+    "country": "FRA",
     "location": "Bastia",
     "stadium": "Stade d'Erbajolo",
     "stadium_capacity": 1600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.86
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "Romania",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 16
     }
   },
   {
     "name": "Pau FC",
-    "country": "France",
+    "country": "FRA",
     "location": "Pau",
     "stadium": "Nouste Camp",
     "stadium_capacity": 4031,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.89
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 15
     }
   },
   {
     "name": "USL Dunkerque",
-    "country": "France",
+    "country": "FRA",
     "location": "Dunkerque",
     "stadium": "Marcel-Tribut",
     "stadium_capacity": 4200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.8
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 17
     }
   },
   {
     "name": "ES Uz\\u00e8s Pont du Gard",
-    "country": "France",
+    "country": "FRA",
     "location": "Uz\\u00e8s",
     "stadium": "Louis Pautex",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.78
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.22
-        }
-      ],
       "mu": 59,
       "sigma": 7
     }
   },
   {
     "name": "JA Drancy",
-    "country": "France",
+    "country": "FRA",
     "location": "Drancy",
     "stadium": "Stade Charles Sage",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.83
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.09
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.09
-        }
-      ],
       "mu": 77,
       "sigma": 14
     }
   },
   {
     "name": "AC Amiens",
-    "country": "France",
+    "country": "FRA",
     "location": "Amiens",
     "stadium": "Stade Jean-Bouin",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.84
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 32
     }
   },
   {
     "name": "Tr\\u00e9lissac FC",
-    "country": "France",
+    "country": "FRA",
     "location": "Tr\\u00e9lissac",
     "stadium": "Stade Firmin Daudou",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.78
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.05
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        },
-        {
-          "name": "Malta",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 9
     }
   },
   {
     "name": "SO Chamb\\u00e9ry Foot",
-    "country": "France",
+    "country": "FRA",
     "location": "Chamb\\u00e9ry",
     "stadium": "Stade Jaques Level",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.75
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.06
-        },
-        {
-          "name": "Poland",
-          "probability": 0.06
-        },
-        {
-          "name": "China",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 14
     }
   },
   {
     "name": "Les Herbiers VF",
-    "country": "France",
+    "country": "FRA",
     "location": "Les Herbiers",
     "stadium": "Stade Massabielle",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.77
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.23
-        }
-      ],
       "mu": 55,
       "sigma": 32
     }
   },
   {
     "name": "Rodez AF",
-    "country": "France",
+    "country": "FRA",
     "location": "Rodez",
     "stadium": "Stade Paul Lignon",
     "stadium_capacity": 5955,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.71
-        },
-        {
-          "name": "Spain",
-          "probability": 0.1
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.1
-        },
-        {
-          "name": "Australia",
-          "probability": 0.1
-        }
-      ],
       "mu": 57,
       "sigma": 9
     }
   },
   {
     "name": "Jura Sud Foot",
-    "country": "France",
+    "country": "FRA",
     "location": "Lavans-l\\u00e8s-Saint-Claude",
     "stadium": "Stade Municipal de Moirans",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.76
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.08
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.08
-        },
-        {
-          "name": "Togo",
-          "probability": 0.08
-        }
-      ],
       "mu": 64,
       "sigma": 8
     }
   },
   {
     "name": "Sporting Club Toulon",
-    "country": "France",
+    "country": "FRA",
     "location": "Toulon",
     "stadium": "Stade Bon Rencontre",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.71
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.15
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.15
-        }
-      ],
       "mu": 71,
       "sigma": 12
     }
   },
   {
     "name": "Olympique Saint-Quentin",
-    "country": "France",
+    "country": "FRA",
     "location": "Saint-Quentin",
     "stadium": "Stade Paul Debr\\u00e9sie",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.89
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.05
-        }
-      ],
       "mu": 82,
       "sigma": 18
     }
   },
   {
     "name": "FC Sens",
-    "country": "France",
+    "country": "FRA",
     "location": "Sens",
     "stadium": "Stade Fernand Sastre",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.9
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.02
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.02
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.02
-        },
-        {
-          "name": "Iran",
-          "probability": 0.02
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "US Sarre-Union",
-    "country": "France",
+    "country": "FRA",
     "location": "Sarre-Union",
     "stadium": "Stade Omnisports",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.88
-        },
-        {
-          "name": "Wales",
-          "probability": 0.12
-        }
-      ],
       "mu": 62,
       "sigma": 33
     }
   },
   {
     "name": "FC Montceau Bourgogne",
-    "country": "France",
+    "country": "FRA",
     "location": "Montceau-les-Mines",
     "stadium": "Stade des Alouettes",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.85
-        },
-        {
-          "name": "Finland",
-          "probability": 0.15
-        }
-      ],
       "mu": 69,
       "sigma": 12
     }
   },
   {
     "name": "FC Borgo",
-    "country": "France",
+    "country": "FRA",
     "location": "Borgo",
     "stadium": "Stade Paul-Antoniotti",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.71
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.15
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.15
-        }
-      ],
       "mu": 70,
       "sigma": 10
     }
   },
   {
     "name": "FC Martigues",
-    "country": "France",
+    "country": "FRA",
     "location": "Martigues",
     "stadium": "Stade Francis Turcan",
     "stadium_capacity": 11500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.82
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.18
-        }
-      ],
       "mu": 60,
       "sigma": 29
     }
   },
   {
     "name": "Feignies Aulnoye",
-    "country": "France",
+    "country": "FRA",
     "location": "Feignies",
     "stadium": "Stade Didier Eloy",
     "stadium_capacity": 2300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.81
-        },
-        {
-          "name": "United States",
-          "probability": 0.09
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.09
-        }
-      ],
       "mu": 74,
       "sigma": 14
     }
   },
   {
     "name": "Saint-Pryv\\u00e9 Saint-Hilaire",
-    "country": "France",
+    "country": "FRA",
     "location": "Saint-Pryv\\u00e9-Saint-Mesmin",
     "stadium": "Le Grand Clos",
     "stadium_capacity": 1800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.89
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        }
-      ],
       "mu": 85,
       "sigma": 8
     }
   },
   {
     "name": "Marseille Endoume",
-    "country": "France",
+    "country": "FRA",
     "location": "Marseille",
     "stadium": "Stade le Cesne",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.78
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.07
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        }
-      ],
       "mu": 69,
       "sigma": 11
     }
   },
   {
     "name": "Stade Briochin",
-    "country": "France",
+    "country": "FRA",
     "location": "Saint-Brieuc",
     "stadium": "Fred-Aubert Stadium",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.9
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        }
-      ],
       "mu": 68,
       "sigma": 19
     }
   },
   {
     "name": "Paris 13 Atletico",
-    "country": "France",
+    "country": "FRA",
     "location": "Paris",
     "stadium": "Stade Boutroux",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.77
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.08
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.08
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.08
-        }
-      ],
       "mu": 55,
       "sigma": 15
     }
   },
   {
     "name": "Stade Montois",
-    "country": "France",
+    "country": "FRA",
     "location": "Mont-de-Marsan",
     "stadium": "Stade de l'Argent\\u00e9",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "France",
-          "probability": 0.84
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.04
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 15
     }
   },
   {
     "name": "Torpedo Kutaisi",
-    "country": "Georgia",
+    "country": "GEO",
     "location": "Kutaisi",
     "stadium": "Givi Kiladze",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Georgia",
-          "probability": 0.82
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 34
     }
   },
   {
     "name": "FC Zugdidi",
-    "country": "Georgia",
+    "country": "GEO",
     "location": "Zugdidi",
     "stadium": "Gulia Tutberidze",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Georgia",
-          "probability": 0.9
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.02
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.02
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.02
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.02
-        }
-      ],
       "mu": 83,
       "sigma": 35
     }
   },
   {
     "name": "Liakhvi Tskhinvali",
-    "country": "Georgia",
+    "country": "GEO",
     "location": "Gori",
     "stadium": "Kartlis Stadioni",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Georgia",
-          "probability": 0.88
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.04
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        }
-      ],
       "mu": 61,
       "sigma": 14
     }
   },
   {
     "name": "Samgurali Tskhaltubo",
-    "country": "Georgia",
+    "country": "GEO",
     "location": "Tskhaltubo",
     "stadium": "Tskhaltubo Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Georgia",
-          "probability": 0.85
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.03
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.03
-        }
-      ],
       "mu": 63,
       "sigma": 34
     }
   },
   {
     "name": "Borussia Dortmund",
-    "country": "Germany",
+    "country": "GER",
     "location": "Dortmund",
     "stadium": "Signal Iduna Park",
     "stadium_capacity": 81365,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.88
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.12
-        }
-      ],
       "mu": 58,
       "sigma": 34
     }
   },
   {
     "name": "Rot-Wei\\u00df Erfurt",
-    "country": "Germany",
+    "country": "GER",
     "location": "Erfurt",
     "stadium": "Steigerwaldstadion",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "Finland",
-          "probability": 0.07
-        },
-        {
-          "name": "Panama",
-          "probability": 0.07
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.07
-        }
-      ],
       "mu": 49,
       "sigma": 30
     }
   },
   {
     "name": "Rot-Wei\\u00df Essen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Essen",
     "stadium": "Georg Melches",
     "stadium_capacity": 21500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.86
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.07
-        }
-      ],
       "mu": 79,
       "sigma": 34
     }
   },
   {
     "name": "SSV Reutlingen 05",
-    "country": "Germany",
+    "country": "GER",
     "location": "Reutlingen",
     "stadium": "Kreuzeiche",
     "stadium_capacity": 12734,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.76
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 82,
       "sigma": 6
     }
   },
   {
     "name": "Werder Bremen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Bremen",
     "stadium": "Weserstadion",
     "stadium_capacity": 43087,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.76
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.05
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        },
-        {
-          "name": "Peru",
-          "probability": 0.05
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.05
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.05
-        }
-      ],
       "mu": 69,
       "sigma": 12
     }
   },
   {
     "name": "TSV 1860 M\\u00fcnchen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Munich",
     "stadium": "Gr\\u00fcnwalder Stadion",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.9
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.1
-        }
-      ],
       "mu": 78,
       "sigma": 17
     }
   },
   {
     "name": "VfB Stuttgart",
-    "country": "Germany",
+    "country": "GER",
     "location": "Stuttgart",
     "stadium": "Mercedes-Benz Arena",
     "stadium_capacity": 60449,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.71
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.15
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.15
-        }
-      ],
       "mu": 77,
       "sigma": 5
     }
   },
   {
     "name": "Eintracht Braunschweig",
-    "country": "Germany",
+    "country": "GER",
     "location": "Braunschweig",
     "stadium": "Eintracht Stadion",
     "stadium_capacity": 23500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.03
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "Canada",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 21
     }
   },
   {
     "name": "SC Paderborn 07",
-    "country": "Germany",
+    "country": "GER",
     "location": "Paderborn",
     "stadium": "Benteler-Arena",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Peru",
-          "probability": 0.15
-        }
-      ],
       "mu": 58,
       "sigma": 9
     }
   },
   {
     "name": "Sportfreunde Siegen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Siegen",
     "stadium": "Leimbachstadion",
     "stadium_capacity": 18500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.1
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 15
     }
   },
   {
     "name": "1. FC Union Berlin",
-    "country": "Germany",
+    "country": "GER",
     "location": "Berlin",
     "stadium": "Alte F\\u00f6rsterei",
     "stadium_capacity": 22012,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.82
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.06
-        },
-        {
-          "name": "Poland",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 16
     }
   },
   {
     "name": "TSG 1899 Hoffenheim",
-    "country": "Germany",
+    "country": "GER",
     "location": "Sinsheim",
     "stadium": "Rhein-Neckar-Arena",
     "stadium_capacity": 30164,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.21
-        }
-      ],
       "mu": 70,
       "sigma": 23
     }
   },
   {
     "name": "Holstein Kiel",
-    "country": "Germany",
+    "country": "GER",
     "location": "Kiel",
     "stadium": "Holstein-Stadion",
     "stadium_capacity": 15034,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.76
-        },
-        {
-          "name": "Laos",
-          "probability": 0.08
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.08
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.08
-        }
-      ],
       "mu": 68,
       "sigma": 19
     }
   },
   {
     "name": "Bayern M\\u00fcnchen II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Munich",
     "stadium": "Gr\\u00fcnwalder Stadion",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 13
     }
   },
   {
     "name": "Hessen Kassel",
-    "country": "Germany",
+    "country": "GER",
     "location": "Kassel",
     "stadium": "Auestadion",
     "stadium_capacity": 17993,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.73
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.14
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.14
-        }
-      ],
       "mu": 49,
       "sigma": 26
     }
   },
   {
     "name": "Preussen M\\u00fcnster",
-    "country": "Germany",
+    "country": "GER",
     "location": "M\\u00fcnster",
     "stadium": "Preu\\u00dfen-Stadion",
     "stadium_capacity": 15050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.88
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        }
-      ],
       "mu": 85,
       "sigma": 29
     }
   },
   {
     "name": "Eintracht Trier",
-    "country": "Germany",
+    "country": "GER",
     "location": "Trier",
     "stadium": "Moselstadion",
     "stadium_capacity": 10256,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "Togo",
-          "probability": 0.1
-        },
-        {
-          "name": "Austria",
-          "probability": 0.1
-        }
-      ],
       "mu": 50,
       "sigma": 31
     }
   },
   {
     "name": "Sportfreunde Lotte",
-    "country": "Germany",
+    "country": "GER",
     "location": "Lotte",
     "stadium": "connectM-Arena",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.81
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.19
-        }
-      ],
       "mu": 72,
       "sigma": 20
     }
   },
   {
     "name": "VfB Oldenburg",
-    "country": "Germany",
+    "country": "GER",
     "location": "Oldenburg",
     "stadium": "Marschweg-Stadion",
     "stadium_capacity": 15200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 5
     }
   },
   {
     "name": "Hallescher FC",
-    "country": "Germany",
+    "country": "GER",
     "location": "Halle an der Saale",
     "stadium": "Erdgas Sportpark",
     "stadium_capacity": 15057,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.21
-        }
-      ],
       "mu": 49,
       "sigma": 25
     }
   },
   {
     "name": "Wormatia Worms",
-    "country": "Germany",
+    "country": "GER",
     "location": "Worms",
     "stadium": "EWR-Arena",
     "stadium_capacity": 5724,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.71
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "Greece",
-          "probability": 0.07
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.07
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.07
-        }
-      ],
       "mu": 66,
       "sigma": 17
     }
   },
   {
     "name": "W\\u00fcrzburger Kickers",
-    "country": "Germany",
+    "country": "GER",
     "location": "W\\u00fcrzburg",
     "stadium": "flyeralarm Arena",
     "stadium_capacity": 13090,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.83
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.03
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        }
-      ],
       "mu": 60,
       "sigma": 29
     }
   },
   {
     "name": "TSG Hoffenheim II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Sinsheim",
     "stadium": "Dietmar Hopp",
     "stadium_capacity": 6350,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.8
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        }
-      ],
       "mu": 85,
       "sigma": 27
     }
   },
   {
     "name": "Werder Bremen II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Bremen",
     "stadium": "Weserstadion, Platz 11",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.72
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.28
-        }
-      ],
       "mu": 60,
       "sigma": 13
     }
   },
   {
     "name": "BSV SW Rehden",
-    "country": "Germany",
+    "country": "GER",
     "location": "Rehden",
     "stadium": "Sportplatz Waldsportst\\u00e4tten",
     "stadium_capacity": 4350,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.84
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.16
-        }
-      ],
       "mu": 82,
       "sigma": 27
     }
   },
   {
     "name": "SV Meppen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Meppen",
     "stadium": "MEP-Arena",
     "stadium_capacity": 16500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.76
-        },
-        {
-          "name": "Wales",
-          "probability": 0.24
-        }
-      ],
       "mu": 70,
       "sigma": 27
     }
   },
   {
     "name": "Hannover 96 II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Hannover",
     "stadium": "M\\u00fchlenholzweg",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.83
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.03
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        }
-      ],
       "mu": 84,
       "sigma": 35
     }
   },
   {
     "name": "SV Wilhelmshaven",
-    "country": "Germany",
+    "country": "GER",
     "location": "Wilhelmshaven",
     "stadium": "Jadestadion",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.84
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.05
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        }
-      ],
       "mu": 83,
       "sigma": 11
     }
   },
   {
     "name": "Borussia M\\u00f6nchengladbach II",
-    "country": "Germany",
+    "country": "GER",
     "location": "M\\u00f6nchengladbach",
     "stadium": "Grenzlandstadion",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.72
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.28
-        }
-      ],
       "mu": 78,
       "sigma": 28
     }
   },
   {
     "name": "FC 08 Homburg",
-    "country": "Germany",
+    "country": "GER",
     "location": "Homburg",
     "stadium": "Waldstadion Homburg",
     "stadium_capacity": 21813,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.76
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.06
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        }
-      ],
       "mu": 68,
       "sigma": 17
     }
   },
   {
     "name": "SC Weiche Flensburg 08",
-    "country": "Germany",
+    "country": "GER",
     "location": "Flensburg",
     "stadium": "Manfred-Werner-Stadion",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.89
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.03
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.03
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.03
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        }
-      ],
       "mu": 45,
       "sigma": 25
     }
   },
   {
     "name": "FC St. Pauli II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Hamburg",
     "stadium": "Stadion Hoheluft",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.82
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.09
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.09
-        }
-      ],
       "mu": 46,
       "sigma": 31
     }
   },
   {
     "name": "SV Waldhof Mannheim",
-    "country": "Germany",
+    "country": "GER",
     "location": "Mannheim",
     "stadium": "Carl-Benz-Stadion",
     "stadium_capacity": 27000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.87
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        }
-      ],
       "mu": 69,
       "sigma": 32
     }
   },
   {
     "name": "SG Wattenscheid 09",
-    "country": "Germany",
+    "country": "GER",
     "location": "Wattenscheid",
     "stadium": "Lohrheidestadion",
     "stadium_capacity": 16233,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.79
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 24
     }
   },
   {
     "name": "ZFC Meuselwitz",
-    "country": "Germany",
+    "country": "GER",
     "location": "Meuselwitz",
     "stadium": "bluechip-Arena",
     "stadium_capacity": 5260,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.72
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.28
-        }
-      ],
       "mu": 62,
       "sigma": 8
     }
   },
   {
     "name": "BFC Dynamo",
-    "country": "Germany",
+    "country": "GER",
     "location": "Berlin",
     "stadium": "Friedrich-Ludwig-Jahn-Sportpark",
     "stadium_capacity": 19708,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.74
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.26
-        }
-      ],
       "mu": 67,
       "sigma": 21
     }
   },
   {
     "name": "SV Rochling Volklingen",
-    "country": "Germany",
+    "country": "GER",
     "location": "V\\u00f6lklingen",
     "stadium": "Hermann-Neuberger-Stadion",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.73
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.09
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.09
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.09
-        }
-      ],
       "mu": 58,
       "sigma": 9
     }
   },
   {
     "name": "TSV 1860 Rosenheim",
-    "country": "Germany",
+    "country": "GER",
     "location": "Rosenheim",
     "stadium": "TSV Stadion",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.81
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.19
-        }
-      ],
       "mu": 68,
       "sigma": 29
     }
   },
   {
     "name": "FSV Union F\\u00fcrstenwalde",
-    "country": "Germany",
+    "country": "GER",
     "location": "F\\u00fcrstenwalde/Spree",
     "stadium": "Friesenstadion",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.03
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.03
-        }
-      ],
       "mu": 66,
       "sigma": 29
     }
   },
   {
     "name": "FSV Optik Rathenow",
-    "country": "Germany",
+    "country": "GER",
     "location": "Rathenow",
     "stadium": "Vogelgesang",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.82
-        },
-        {
-          "name": "Finland",
-          "probability": 0.18
-        }
-      ],
       "mu": 63,
       "sigma": 13
     }
   },
   {
     "name": "1. FC Kaan-Marienborn",
-    "country": "Germany",
+    "country": "GER",
     "location": "Kaan-Marienborn",
     "stadium": "Herkules-Arena Im Breitenbachtal",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "Angola",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 31
     }
   },
   {
     "name": "FC Pipinsried",
-    "country": "Germany",
+    "country": "GER",
     "location": "Pipinsried",
     "stadium": "Stadion an der Reichertshausener Stra\\u00dfe",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.86
-        },
-        {
-          "name": "Poland",
-          "probability": 0.14
-        }
-      ],
       "mu": 53,
       "sigma": 18
     }
   },
   {
     "name": "FC Ingolstadt 04 II",
-    "country": "Germany",
+    "country": "GER",
     "location": "Ingolstadt",
     "stadium": "Tuja-Stadion",
     "stadium_capacity": 11400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.78
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.22
-        }
-      ],
       "mu": 83,
       "sigma": 34
     }
   },
   {
     "name": "FC Giessen",
-    "country": "Germany",
+    "country": "GER",
     "location": "Giessen",
     "stadium": "Waldstadion",
     "stadium_capacity": 4999,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.73
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Panama",
-          "probability": 0.07
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.07
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.07
-        }
-      ],
       "mu": 53,
       "sigma": 20
     }
   },
   {
     "name": "Greifswalder FC",
-    "country": "Germany",
+    "country": "GER",
     "location": "Greifswald",
     "stadium": "Volksstadion Greifswald",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Germany",
-          "probability": 0.85
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Spain",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 6
     }
   },
   {
     "name": "Liberty Professionals",
-    "country": "Ghana",
+    "country": "GHA",
     "location": "Dansoman",
     "stadium": "Dansoman Park",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ghana",
-          "probability": 0.86
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Romania",
-          "probability": 0.03
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.03
-        }
-      ],
       "mu": 53,
       "sigma": 29
     }
   },
   {
     "name": "Berekum Chelsea",
-    "country": "Ghana",
+    "country": "GHA",
     "location": "Berekum",
     "stadium": "Berekum Sports Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ghana",
-          "probability": 0.8
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.2
-        }
-      ],
       "mu": 77,
       "sigma": 6
     }
   },
   {
     "name": "Europa FC",
-    "country": "Gibraltar",
+    "country": "GIB",
     "location": "Gibraltar",
     "stadium": "Victoria Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Gibraltar",
-          "probability": 0.73
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.09
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.09
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.09
-        }
-      ],
       "mu": 79,
       "sigma": 10
     }
   },
   {
     "name": "St Joseph's FC",
-    "country": "Gibraltar",
+    "country": "GIB",
     "location": "Gibraltar",
     "stadium": "Victoria Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Gibraltar",
-          "probability": 0.71
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.06
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.06
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.06
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.06
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        }
-      ],
       "mu": 45,
       "sigma": 32
     }
   },
   {
     "name": "Mons Calpe SC",
-    "country": "Gibraltar",
+    "country": "GIB",
     "location": "Gibraltar",
     "stadium": "Victoria Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Gibraltar",
-          "probability": 0.85
-        },
-        {
-          "name": "Angola",
-          "probability": 0.15
-        }
-      ],
       "mu": 54,
       "sigma": 17
     }
   },
   {
     "name": "Olympiacos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Piraeus",
     "stadium": "Georgios Karaiskakis Stadium",
     "stadium_capacity": 33330,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.88
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 28
     }
   },
   {
     "name": "AO Xanthi",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Xanthi",
     "stadium": "Skoda Xanthi Arena",
     "stadium_capacity": 7422,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.74
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.07
-        },
-        {
-          "name": "France",
-          "probability": 0.07
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.07
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        }
-      ],
       "mu": 67,
       "sigma": 31
     }
   },
   {
     "name": "Ionikos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Piraeus",
     "stadium": "Neapolis",
     "stadium_capacity": 5850,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.72
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.06
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.06
-        },
-        {
-          "name": "Laos",
-          "probability": 0.06
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 12
     }
   },
   {
     "name": "Atromitos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Peristeri",
     "stadium": "Peristeri Stadium",
     "stadium_capacity": 8939,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.8
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.07
-        }
-      ],
       "mu": 46,
       "sigma": 26
     }
   },
   {
     "name": "APO Levadiakos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Levadia",
     "stadium": "Levadias Stadium",
     "stadium_capacity": 5915,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.89
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        },
-        {
-          "name": "United States",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.03
-        }
-      ],
       "mu": 50,
       "sigma": 25
     }
   },
   {
     "name": " Akratitos ",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Ano Liossia",
     "stadium": "Yannis Pathiakakis Stadium",
     "stadium_capacity": 4944,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.77
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.11
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.11
-        }
-      ],
       "mu": 59,
       "sigma": 16
     }
   },
   {
     "name": "Ergotelis",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Heraklion",
     "stadium": "Pankritio",
     "stadium_capacity": 26240,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.83
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.03
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        },
-        {
-          "name": "Chile",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        }
-      ],
       "mu": 66,
       "sigma": 34
     }
   },
   {
     "name": "Panserraikos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Serres",
     "stadium": "Serres Stadium",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.84
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.03
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.03
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.03
-        }
-      ],
       "mu": 82,
       "sigma": 17
     }
   },
   {
     "name": "Thrasivoulos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Fyli",
     "stadium": "Fyli Stadium",
     "stadium_capacity": 3142,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.86
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 25
     }
   },
   {
     "name": "Doxa Dramas",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Drama",
     "stadium": "Doxa",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.86
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.04
-        }
-      ],
       "mu": 50,
       "sigma": 24
     }
   },
   {
     "name": "AO Platanias",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Platanias",
     "stadium": "Perivolia Stadium",
     "stadium_capacity": 3700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.76
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "Australia",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.06
-        },
-        {
-          "name": "France",
-          "probability": 0.06
-        }
-      ],
       "mu": 83,
       "sigma": 6
     }
   },
   {
     "name": "Pierikos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Katerini",
     "stadium": "Municipal Stadium of Katerini",
     "stadium_capacity": 4956,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.83
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 33
     }
   },
   {
     "name": "Anagennisi Epanomis",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Epanomi",
     "stadium": "Nikos Sarafis",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.84
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.16
-        }
-      ],
       "mu": 78,
       "sigma": 35
     }
   },
   {
     "name": "Ethnikos Gazorou",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Gazoros Serres",
     "stadium": "Serres Stadium",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.86
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 14
     }
   },
   {
     "name": "Iraklis Psachna",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Psachna",
     "stadium": "Psachna Municipal Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.85
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        }
-      ],
       "mu": 45,
       "sigma": 9
     }
   },
   {
     "name": "Proodeftiki",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Korydallos",
     "stadium": "Municipal Stadium of Nikaia",
     "stadium_capacity": 4361,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.86
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.14
-        }
-      ],
       "mu": 60,
       "sigma": 32
     }
   },
   {
     "name": "PAE Chania",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Chania",
     "stadium": "Perivolia Stadium",
     "stadium_capacity": 3700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.84
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.08
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.08
-        }
-      ],
       "mu": 75,
       "sigma": 19
     }
   },
   {
     "name": "Fokikos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Phocis",
     "stadium": "Dimotiko Stadio Amfissas",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.74
-        },
-        {
-          "name": "Italy",
-          "probability": 0.09
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.09
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.09
-        }
-      ],
       "mu": 55,
       "sigma": 34
     }
   },
   {
     "name": "Kozani FC",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Kozani",
     "stadium": "Kozani Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.86
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.07
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.07
-        }
-      ],
       "mu": 79,
       "sigma": 30
     }
   },
   {
     "name": "Irodotos",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Iraklio Crete",
     "stadium": "Nea Alikarnassos Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.84
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.16
-        }
-      ],
       "mu": 54,
       "sigma": 26
     }
   },
   {
     "name": "Panegialios",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Aigio",
     "stadium": "Aigio",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.83
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.03
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        }
-      ],
       "mu": 77,
       "sigma": 9
     }
   },
   {
     "name": "Kampaniakos FC",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Chalastra",
     "stadium": "Kampaniakos Stadium",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.79
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        }
-      ],
       "mu": 71,
       "sigma": 34
     }
   },
   {
     "name": "Byzantio Kokkinochoma",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Kokkinochoma",
     "stadium": "Kokkinochoma Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.74
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.26
-        }
-      ],
       "mu": 52,
       "sigma": 22
     }
   },
   {
     "name": "Sparta",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Sparta",
     "stadium": "Municipal Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.9
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.02
-        },
-        {
-          "name": "Canada",
-          "probability": 0.02
-        },
-        {
-          "name": "Austria",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        }
-      ],
       "mu": 63,
       "sigma": 17
     }
   },
   {
     "name": "APE Langadas",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Langadas",
     "stadium": "Dimotiko Gipedo Lagkadas",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.76
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        }
-      ],
       "mu": 62,
       "sigma": 32
     }
   },
   {
     "name": "Kifisia FC",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Kifisia",
     "stadium": "Municipal Kifisia Stadium",
     "stadium_capacity": 1050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.74
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.05
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.05
-        }
-      ],
       "mu": 64,
       "sigma": 22
     }
   },
   {
     "name": "Achaiki FC",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Kato Achaia",
     "stadium": "Municipal Kato Achaia Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.85
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 5
     }
   },
   {
     "name": "Volos NFC",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Volos",
     "stadium": "Panthessaliko",
     "stadium_capacity": 23000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.87
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.03
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 29
     }
   },
   {
     "name": "Asteras Amaliadas",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Amaliada",
     "stadium": "Municipal Stadium of Amaliada",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.74
-        },
-        {
-          "name": "Laos",
-          "probability": 0.26
-        }
-      ],
       "mu": 79,
       "sigma": 34
     }
   },
   {
     "name": "Asteras Itea",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Itea",
     "stadium": "Itea Municipal Stadium",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.72
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.09
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.09
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.09
-        }
-      ],
       "mu": 75,
       "sigma": 7
     }
   },
   {
     "name": "AE Lefkimmi",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Lefkimmi",
     "stadium": "Lefkimmi Municipal Stadium",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.83
-        },
-        {
-          "name": "Peru",
-          "probability": 0.17
-        }
-      ],
       "mu": 78,
       "sigma": 35
     }
   },
   {
     "name": "Asteras Vlachioti",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Laconia",
     "stadium": "Vlachiotis Municipal Stadium",
     "stadium_capacity": 600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.83
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.06
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.06
-        }
-      ],
       "mu": 72,
       "sigma": 30
     }
   },
   {
     "name": "GS Ilioupolis",
-    "country": "Greece",
+    "country": "GRE",
     "location": "Ilioupoli",
     "stadium": "Ilioupoli Municipal Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Greece",
-          "probability": 0.89
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.11
-        }
-      ],
       "mu": 70,
       "sigma": 9
     }
   },
   {
     "name": "CD Suchitep\\u00e9quez",
-    "country": "Guatemala",
+    "country": "GUA",
     "location": "Mazatenango",
     "stadium": "Carlos Salazar Hijo",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Guatemala",
-          "probability": 0.8
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 25
     }
   },
   {
     "name": "Antigua GFC",
-    "country": "Guatemala",
+    "country": "GUA",
     "location": "Antigua",
     "stadium": "Estadio Pensativo",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Guatemala",
-          "probability": 0.84
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.08
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.08
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "Halcones FC",
-    "country": "Guatemala",
+    "country": "GUA",
     "location": "Huehuetenango",
     "stadium": "Estadio Los Cuchumatanes",
     "stadium_capacity": 5340,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Guatemala",
-          "probability": 0.76
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        }
-      ],
       "mu": 74,
       "sigma": 15
     }
   },
   {
     "name": "Deportivo Siquinal\\u00e1",
-    "country": "Guatemala",
+    "country": "GUA",
     "location": "Siquinal\\u00e1",
     "stadium": "Estadio Sicay Paz",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Guatemala",
-          "probability": 0.88
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.06
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.06
-        }
-      ],
       "mu": 69,
       "sigma": 29
     }
   },
   {
     "name": "Alpha United",
-    "country": "Guyana",
+    "country": "GUY",
     "location": "Georgetown",
     "stadium": "Bourda Cricket Ground",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Guyana",
-          "probability": 0.84
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.05
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        }
-      ],
       "mu": 63,
       "sigma": 12
     }
   },
   {
     "name": "Parrillas One",
-    "country": "Honduras",
+    "country": "HON",
     "location": "San Pedro Sula",
     "stadium": "Estadio Le\\u00f3n G\\u00f3mez",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Honduras",
-          "probability": 0.81
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 17
     }
   },
   {
     "name": "Real de Minas",
-    "country": "Honduras",
+    "country": "HON",
     "location": "Tegucigalpa",
     "stadium": "Estadio Birichiche",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Honduras",
-          "probability": 0.88
-        },
-        {
-          "name": "Panama",
-          "probability": 0.02
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.02
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.02
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.02
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.02
-        }
-      ],
       "mu": 76,
       "sigma": 11
     }
   },
   {
     "name": "Happy Valley AA",
-    "country": "Hong Kong",
+    "country": "HKG",
     "location": "Hong Kong",
     "stadium": "Hammer Hill Sports Ground",
     "stadium_capacity": 2200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hong Kong",
-          "probability": 0.9
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.02
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.02
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.02
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.02
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.02
-        }
-      ],
       "mu": 84,
       "sigma": 15
     }
   },
   {
     "name": "Zalaegerszegi TE",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Zalaegerszeg",
     "stadium": "ZTE Arena",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.88
-        },
-        {
-          "name": "Oman",
-          "probability": 0.12
-        }
-      ],
       "mu": 82,
       "sigma": 15
     }
   },
   {
     "name": "Di\\u00f3sgy\\u0151ri VTK",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Miskolc",
     "stadium": "Andr\\u00e1ssy utca",
     "stadium_capacity": 17500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.9
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.02
-        },
-        {
-          "name": "Russia",
-          "probability": 0.02
-        },
-        {
-          "name": "Finland",
-          "probability": 0.02
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.02
-        },
-        {
-          "name": "China",
-          "probability": 0.02
-        }
-      ],
       "mu": 53,
       "sigma": 10
     }
   },
   {
     "name": "Vasas SC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Budapest",
     "stadium": "Illovszky Rudolf",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.88
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.02
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.02
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.02
-        },
-        {
-          "name": "Panama",
-          "probability": 0.02
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.02
-        }
-      ],
       "mu": 79,
       "sigma": 9
     }
   },
   {
     "name": "Pecsi MFC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "P\\u00e9cs",
     "stadium": "\\u00dajmecsekalja",
     "stadium_capacity": 7160,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.85
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        }
-      ],
       "mu": 64,
       "sigma": 31
     }
   },
   {
     "name": "Gy\\u0151ri ETO",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Gyor",
     "stadium": "ETO Park",
     "stadium_capacity": 15600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.87
-        },
-        {
-          "name": "Panama",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 22
     }
   },
   {
     "name": "Budapest Honv\\u00e9d",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Budapest",
     "stadium": "Bozsik-stadion",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.86
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "Spain",
-          "probability": 0.04
-        }
-      ],
       "mu": 47,
       "sigma": 5
     }
   },
   {
     "name": "BFC Si\\u00f3fok",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Siofok",
     "stadium": "R\\u00e9vesz G\\u00e9za Stadion",
     "stadium_capacity": 10500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.89
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 14
     }
   },
   {
     "name": "Ny\\u00edregyh\\u00e1za Spartacus",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Ny\\u00edregyh\\u00e1za",
     "stadium": "V\\u00e1rosi Stadion",
     "stadium_capacity": 13501,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.84
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.16
-        }
-      ],
       "mu": 82,
       "sigma": 12
     }
   },
   {
     "name": "Ferencv\\u00e1rosi TC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Budapest",
     "stadium": "Groupama Arena",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.87
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 7
     }
   },
   {
     "name": "Gyirm\\u00f3t SE",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Gy\\u0151r",
     "stadium": "M\\u00e9nf\\u0151i \\u00fati sporttelep",
     "stadium_capacity": 2700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.79
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.1
-        },
-        {
-          "name": "Panama",
-          "probability": 0.1
-        }
-      ],
       "mu": 65,
       "sigma": 35
     }
   },
   {
     "name": "Pusk\\u00e1s Akad\\u00e9mia FC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Felcs\\u00fat",
     "stadium": "Pancho Ar\\u00e9na",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.86
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.07
-        }
-      ],
       "mu": 72,
       "sigma": 8
     }
   },
   {
     "name": "Balmaz\\u00fajv\\u00e1rosi FC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Balmaz\\u00fajv\\u00e1ros",
     "stadium": "Balmaz\\u00fajv\\u00e1rosi V\\u00e1rosi Sportp\\u00e1lya",
     "stadium_capacity": 2300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.71
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.15
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.15
-        }
-      ],
       "mu": 82,
       "sigma": 11
     }
   },
   {
     "name": "Cegl\\u00e9di VSE",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Cegl\\u00e9d",
     "stadium": "Malomt\\u00f3 sz\\u00e9li sporttelep",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.8
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        },
-        {
-          "name": "India",
-          "probability": 0.07
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        }
-      ],
       "mu": 82,
       "sigma": 34
     }
   },
   {
     "name": "Kazincbarcikai SC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Kazincbarcika",
     "stadium": "Pete Andr\\u00e1s Stadion",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.81
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.05
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 34
     }
   },
   {
     "name": "Budafoki MTE",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Budapest",
     "stadium": "Promontor utcai Stadion",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.78
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.22
-        }
-      ],
       "mu": 72,
       "sigma": 7
     }
   },
   {
     "name": "Dorogi FC",
-    "country": "Hungary",
+    "country": "HUN",
     "location": "Dorog",
     "stadium": "Jen\\u0151 Buz\\u00e1nszky Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Hungary",
-          "probability": 0.79
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.05
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 34
     }
   },
   {
     "name": "Fram",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "Reykjav\\u00edk",
     "stadium": "Laugardalsv\\u00f6llur",
     "stadium_capacity": 15427,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.73
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.14
-        },
-        {
-          "name": "Greece",
-          "probability": 0.14
-        }
-      ],
       "mu": 84,
       "sigma": 26
     }
   },
   {
     "name": "KR Reykjav\\u00edk",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "Reykjav\\u00edk",
     "stadium": "KR-v\\u00f6llur",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.89
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.02
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.02
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.02
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.02
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.02
-        }
-      ],
       "mu": 48,
       "sigma": 33
     }
   },
   {
     "name": "Thr\\u00f3ttur",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "Reykjav\\u00edk",
     "stadium": "Valbjarnarv\\u00f6llur",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.72
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.09
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.09
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.09
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "Th\\u00f3r",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "Akureyri",
     "stadium": "\\u00de\\u00f3rsv\\u00f6llur",
     "stadium_capacity": 1550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.77
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.23
-        }
-      ],
       "mu": 49,
       "sigma": 30
     }
   },
   {
     "name": "Haukar",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "Hafnarfj\\u00f6r\\u00f0ur",
     "stadium": "\\u00c1svellir",
     "stadium_capacity": 2120,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.74
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.13
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.13
-        }
-      ],
       "mu": 59,
       "sigma": 31
     }
   },
   {
     "name": "UMF Sindri H\\u00f6fn",
-    "country": "Iceland",
+    "country": "ISL",
     "location": "H\\u00f6fn",
     "stadium": "Sindravellir",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iceland",
-          "probability": 0.71
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.07
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.07
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.07
-        }
-      ],
       "mu": 75,
       "sigma": 23
     }
   },
   {
     "name": "Bengaluru FC",
-    "country": "India",
+    "country": "IND",
     "location": "Bangalore",
     "stadium": "Sree Kanteerava Stadium",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "India",
-          "probability": 0.72
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.14
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.14
-        }
-      ],
       "mu": 84,
       "sigma": 26
     }
   },
   {
     "name": "Odisha FC",
-    "country": "India",
+    "country": "IND",
     "location": "Bhubaneswar",
     "stadium": "Kalinga Stadium",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "India",
-          "probability": 0.77
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.08
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.08
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.08
-        }
-      ],
       "mu": 74,
       "sigma": 35
     }
   },
   {
     "name": "Mumbai City FC",
-    "country": "India",
+    "country": "IND",
     "location": "Mumbai",
     "stadium": "Mumbai Football Arena",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "India",
-          "probability": 0.75
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.12
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.12
-        }
-      ],
       "mu": 71,
       "sigma": 25
     }
   },
   {
     "name": "RoundGlass Punjab",
-    "country": "India",
+    "country": "IND",
     "location": "Chandigarh",
     "stadium": "Guru Nanak Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "India",
-          "probability": 0.86
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.03
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.03
-        },
-        {
-          "name": "Romania",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.03
-        }
-      ],
       "mu": 55,
       "sigma": 9
     }
   },
   {
     "name": "Persipura Jayapura",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Jayapura",
     "stadium": "Mandala Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.81
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.06
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.06
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        }
-      ],
       "mu": 58,
       "sigma": 32
     }
   },
   {
     "name": "Mitra Kukar",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Tenggarong",
     "stadium": "Aji Imbut",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.88
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 18
     }
   },
   {
     "name": "Sriwijaya FC",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Palembang",
     "stadium": "Gelora Sriwijaya Jakabaring",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.78
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 8
     }
   },
   {
     "name": "Arema FC",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Malang",
     "stadium": "Kanjuruhan",
     "stadium_capacity": 55000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.75
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.08
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.08
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.08
-        }
-      ],
       "mu": 48,
       "sigma": 25
     }
   },
   {
     "name": "Bali United",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Gianyar",
     "stadium": "Kapten I Wayan Dipta Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.89
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.03
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.03
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        }
-      ],
       "mu": 62,
       "sigma": 33
     }
   },
   {
     "name": "Persiba Balikpapan",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Balikpapan",
     "stadium": "Persiba Balikpapan",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.87
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.07
-        },
-        {
-          "name": "Poland",
-          "probability": 0.07
-        }
-      ],
       "mu": 60,
       "sigma": 22
     }
   },
   {
     "name": "Persegres Gresik United",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Gresik",
     "stadium": "Gelora Joko Samudro",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.82
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Malta",
-          "probability": 0.05
-        }
-      ],
       "mu": 64,
       "sigma": 32
     }
   },
   {
     "name": "Persikabo 1973",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Bogor",
     "stadium": "Sultan Agung",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.81
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        }
-      ],
       "mu": 83,
       "sigma": 15
     }
   },
   {
     "name": "Bontang FC",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Bontang",
     "stadium": "Mulawarman",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.78
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        }
-      ],
       "mu": 45,
       "sigma": 17
     }
   },
   {
     "name": "PS Barito Putera",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Banjarmasin",
     "stadium": "Demang Lehman",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.87
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "United States",
-          "probability": 0.07
-        }
-      ],
       "mu": 64,
       "sigma": 33
     }
   },
   {
     "name": "Perseman Manokwari",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Manokwari",
     "stadium": "Sanggeng Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.9
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 22
     }
   },
   {
     "name": "Badak Lampung",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Bandar Lampung",
     "stadium": "Sumpah Pemuda Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.83
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.03
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        }
-      ],
       "mu": 66,
       "sigma": 12
     }
   },
   {
     "name": "PSMS Medan",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Medan",
     "stadium": "Stadion Teladan",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.76
-        },
-        {
-          "name": "Canada",
-          "probability": 0.08
-        },
-        {
-          "name": "Iran",
-          "probability": 0.08
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.08
-        }
-      ],
       "mu": 62,
       "sigma": 29
     }
   },
   {
     "name": "Persiraja Banda Aceh",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Banda Aceh",
     "stadium": "Harapan Bangsa Stadium",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.72
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.06
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.06
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 16
     }
   },
   {
     "name": "AHHA PS Pati",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Pati",
     "stadium": "Joyokusumo",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.85
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 18
     }
   },
   {
     "name": "Hizbul Wathan",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Sidoarjo",
     "stadium": "Gelora Delta",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.83
-        },
-        {
-          "name": "Togo",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        }
-      ],
       "mu": 72,
       "sigma": 26
     }
   },
   {
     "name": "Perserang Serang",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Serang",
     "stadium": "Maulana Yusuf",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.74
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.07
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Japan",
-          "probability": 0.07
-        }
-      ],
       "mu": 70,
       "sigma": 19
     }
   },
   {
     "name": "Deltras FC",
-    "country": "Indonesia",
+    "country": "IDN",
     "location": "Sidoarjo",
     "stadium": "Gelora Delta Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Indonesia",
-          "probability": 0.8
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.07
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.07
-        }
-      ],
       "mu": 76,
       "sigma": 27
     }
   },
   {
     "name": "Saipa",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Karaj",
     "stadium": "Enghelab Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.86
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 7
     }
   },
   {
     "name": "Sanat Naft",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Abadan",
     "stadium": "Takhti Stadium (Abadan)",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.82
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.18
-        }
-      ],
       "mu": 55,
       "sigma": 24
     }
   },
   {
     "name": "Esteghlal Khuzestan",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Ahvaz",
     "stadium": "Ghadir Stadium",
     "stadium_capacity": 50199,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.8
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.07
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.07
-        },
-        {
-          "name": "Spain",
-          "probability": 0.07
-        }
-      ],
       "mu": 61,
       "sigma": 30
     }
   },
   {
     "name": "Gostaresh Foolad",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Tabriz",
     "stadium": "Gostaresh Foolad Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.79
-        },
-        {
-          "name": "India",
-          "probability": 0.1
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.1
-        }
-      ],
       "mu": 81,
       "sigma": 9
     }
   },
   {
     "name": "Malavan",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Bandar-e Anzali",
     "stadium": "Takhti Stadium (Anzali)",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.73
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.09
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.09
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.09
-        }
-      ],
       "mu": 54,
       "sigma": 26
     }
   },
   {
     "name": "Shahr Khodro",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Mashhad",
     "stadium": "Samen Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.77
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.23
-        }
-      ],
       "mu": 76,
       "sigma": 23
     }
   },
   {
     "name": "Naft Masjed Soleyman",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Masjed Soleyman",
     "stadium": "Behnam Mohammadi",
     "stadium_capacity": 19745,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.88
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.03
-        },
-        {
-          "name": "Italy",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        }
-      ],
       "mu": 61,
       "sigma": 16
     }
   },
   {
     "name": "Esteghlal Ahvaz",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Ahvaz",
     "stadium": "Takhti Stadium (Ahvaz)",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.87
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 74,
       "sigma": 9
     }
   },
   {
     "name": "Sepidrood Rasht SC",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Rasht",
     "stadium": "Shahid Dr. Azodi",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.88
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.06
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        }
-      ],
       "mu": 76,
       "sigma": 28
     }
   },
   {
     "name": "Gol Gohar Sirjan",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Sirjan",
     "stadium": "Imam Ali",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.86
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.14
-        }
-      ],
       "mu": 73,
       "sigma": 24
     }
   },
   {
     "name": "Mes Kerman",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Kerman",
     "stadium": "Shahid Bahonar Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.89
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.11
-        }
-      ],
       "mu": 67,
       "sigma": 20
     }
   },
   {
     "name": "Havadar SC",
-    "country": "Iran",
+    "country": "IRN",
     "location": "Eslamshahr",
     "stadium": "Shohadaye Eslamshahr",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iran",
-          "probability": 0.85
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        }
-      ],
       "mu": 50,
       "sigma": 35
     }
   },
   {
     "name": "Duhok SC",
-    "country": "Iraq",
+    "country": "IRQ",
     "location": "Duhok",
     "stadium": "Duhok Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iraq",
-          "probability": 0.84
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Panama",
-          "probability": 0.04
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.04
-        }
-      ],
       "mu": 62,
       "sigma": 16
     }
   },
   {
     "name": "Al Naft SC",
-    "country": "Iraq",
+    "country": "IRQ",
     "location": "Baghdad",
     "stadium": "Al Naft Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Iraq",
-          "probability": 0.76
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 33
     }
   },
   {
     "name": "St. Patrick's Athletic",
-    "country": "Ireland",
+    "country": "IRL",
     "location": "Dublin",
     "stadium": "Richmond Park",
     "stadium_capacity": 5340,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ireland",
-          "probability": 0.79
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 18
     }
   },
   {
     "name": "UCD",
-    "country": "Ireland",
+    "country": "IRL",
     "location": "Dublin",
     "stadium": "UCD Bowl",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ireland",
-          "probability": 0.88
-        },
-        {
-          "name": "Oman",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        }
-      ],
       "mu": 53,
       "sigma": 7
     }
   },
   {
     "name": "Finn Harps",
-    "country": "Ireland",
+    "country": "IRL",
     "location": "Ballybofey",
     "stadium": "Finn Park",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ireland",
-          "probability": 0.72
-        },
-        {
-          "name": "France",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.06
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        }
-      ],
       "mu": 50,
       "sigma": 17
     }
   },
   {
     "name": "Monaghan United",
-    "country": "Ireland",
+    "country": "IRL",
     "location": "Monaghan",
     "stadium": "Kingspan Century Park",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ireland",
-          "probability": 0.81
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 35
     }
   },
   {
     "name": "Beitar Jerusalem",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Jerusalem",
     "stadium": "Teddi",
     "stadium_capacity": 34000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.81
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.09
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.09
-        }
-      ],
       "mu": 58,
       "sigma": 16
     }
   },
   {
     "name": "Maccabi Tel Aviv",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Tel Aviv",
     "stadium": "Bloomfield",
     "stadium_capacity": 15478,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.89
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 30
     }
   },
   {
     "name": "Maccabi Netanya",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Netanya",
     "stadium": "Sar Tov Stadium",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.83
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        }
-      ],
       "mu": 45,
       "sigma": 12
     }
   },
   {
     "name": "Hapoel Kfar Saba",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Kfar-Saba",
     "stadium": "Levita",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.88
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.12
-        }
-      ],
       "mu": 61,
       "sigma": 35
     }
   },
   {
     "name": "Hapoel Ra'anana",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Ra'anana",
     "stadium": "Karnei",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.71
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.15
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.15
-        }
-      ],
       "mu": 70,
       "sigma": 12
     }
   },
   {
     "name": "Hakoach Ramat Gan",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Ramat Gan",
     "stadium": "Winter Stadium",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.71
-        },
-        {
-          "name": "Poland",
-          "probability": 0.07
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.07
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 13
     }
   },
   {
     "name": "Hapoel Nof HaGalil",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Nazareth Ilit",
     "stadium": "Green Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.81
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.09
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.09
-        }
-      ],
       "mu": 66,
       "sigma": 25
     }
   },
   {
     "name": "Maccabi Umm Al Fahm",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Umm al-Fahm",
     "stadium": "HaShalom Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.83
-        },
-        {
-          "name": "Spain",
-          "probability": 0.17
-        }
-      ],
       "mu": 68,
       "sigma": 16
     }
   },
   {
     "name": "Hapoel Marmorek",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Rehovot",
     "stadium": "Itztoni Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.73
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.05
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        }
-      ],
       "mu": 79,
       "sigma": 19
     }
   },
   {
     "name": "Hapoel Umm al Fahm",
-    "country": "Israel",
+    "country": "ISR",
     "location": "Umm al-Fahm",
     "stadium": "HaShalom Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Israel",
-          "probability": 0.89
-        },
-        {
-          "name": "Oman",
-          "probability": 0.04
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.04
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        }
-      ],
       "mu": 64,
       "sigma": 27
     }
   },
   {
     "name": "UC AlbinoLeffe",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Bergamo",
     "stadium": "Atleti Azzurri d'Italia",
     "stadium_capacity": 26638,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 9
     }
   },
   {
     "name": "SS Arezzo",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Arezzo",
     "stadium": "Comunale Citt\\u00e0 di Arezzo",
     "stadium_capacity": 13128,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.79
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.21
-        }
-      ],
       "mu": 69,
       "sigma": 5
     }
   },
   {
     "name": "Ascoli Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Ascoli Piceno",
     "stadium": "Cino e Lillo del Duca",
     "stadium_capacity": 20550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.08
-        },
-        {
-          "name": "Albania",
-          "probability": 0.08
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.08
-        }
-      ],
       "mu": 56,
       "sigma": 24
     }
   },
   {
     "name": "Atalanta BC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Bergamo",
     "stadium": "Atleti Azzurri d'Italia",
     "stadium_capacity": 26724,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.79
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.1
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.1
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "SSC Bari",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Bari",
     "stadium": "San Nicola",
     "stadium_capacity": 58270,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.03
-        }
-      ],
       "mu": 69,
       "sigma": 18
     }
   },
   {
     "name": "Bologna FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Bologna",
     "stadium": "Renato Dall'Ara",
     "stadium_capacity": 39444,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Finland",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 13
     }
   },
   {
     "name": "Brescia Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Brescia",
     "stadium": "Mario Rigamonti",
     "stadium_capacity": 27547,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.85
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.08
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.08
-        }
-      ],
       "mu": 63,
       "sigma": 18
     }
   },
   {
     "name": "Cagliari",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Cagliari",
     "stadium": "Sardegna Arena",
     "stadium_capacity": 16233,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.74
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.09
-        },
-        {
-          "name": "Finland",
-          "probability": 0.09
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.09
-        }
-      ],
       "mu": 45,
       "sigma": 8
     }
   },
   {
     "name": "Catania Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Catania",
     "stadium": "Angelo Massimino",
     "stadium_capacity": 23420,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "Iran",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 35
     }
   },
   {
     "name": "US Catanzaro",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Catanzaro",
     "stadium": "Nicola Ceravolo",
     "stadium_capacity": 13619,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.72
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.06
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 8
     }
   },
   {
     "name": "Cesena FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Cesena",
     "stadium": "Stadio Dino Manuzzi",
     "stadium_capacity": 23860,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        }
-      ],
       "mu": 66,
       "sigma": 20
     }
   },
   {
     "name": "Chievo Verona",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Verona",
     "stadium": "Marcantonio Bentegodi",
     "stadium_capacity": 42160,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.07
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 34
     }
   },
   {
     "name": "FC Crotone",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Crotone",
     "stadium": "Ezio Scida",
     "stadium_capacity": 16547,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.82
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.09
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.09
-        }
-      ],
       "mu": 79,
       "sigma": 5
     }
   },
   {
     "name": "Empoli",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Empoli",
     "stadium": "Carlo Castellani",
     "stadium_capacity": 19847,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.83
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.09
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.09
-        }
-      ],
       "mu": 47,
       "sigma": 9
     }
   },
   {
     "name": "ACF Fiorentina",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Firenze",
     "stadium": "Artemio Franchi",
     "stadium_capacity": 47290,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.89
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 52,
       "sigma": 28
     }
   },
   {
     "name": "Genoa CFC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Genoa",
     "stadium": "Luigi Ferraris",
     "stadium_capacity": 36703,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.73
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.05
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 9
     }
   },
   {
     "name": "Internazionale",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Milano",
     "stadium": "Giuseppe Meazza",
     "stadium_capacity": 80018,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Poland",
-          "probability": 0.25
-        }
-      ],
       "mu": 76,
       "sigma": 17
     }
   },
   {
     "name": "Juventus",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Turin",
     "stadium": "Juventus Stadium",
     "stadium_capacity": 41588,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.06
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        }
-      ],
       "mu": 61,
       "sigma": 30
     }
   },
   {
     "name": "SS Lazio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Rome",
     "stadium": "Stadio Olimpico",
     "stadium_capacity": 73261,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.9
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.02
-        },
-        {
-          "name": "France",
-          "probability": 0.02
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.02
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.02
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.02
-        }
-      ],
       "mu": 46,
       "sigma": 19
     }
   },
   {
     "name": "US Livorno",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Livorno",
     "stadium": "Armando Picchi",
     "stadium_capacity": 19238,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        }
-      ],
       "mu": 83,
       "sigma": 24
     }
   },
   {
     "name": "ACR Messina",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Messina",
     "stadium": "Stadio San Filippo",
     "stadium_capacity": 40200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.03
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 28
     }
   },
   {
     "name": "AC Milan",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Milano",
     "stadium": "San Siro",
     "stadium_capacity": 80018,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.78
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 28
     }
   },
   {
     "name": "Modena",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Modena",
     "stadium": "Alberto Braglia",
     "stadium_capacity": 20507,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.74
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 35
     }
   },
   {
     "name": "Palermo FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Palermo",
     "stadium": "Renzo Barbera",
     "stadium_capacity": 36349,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.83
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.03
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 5
     }
   },
   {
     "name": "Parma",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Parma",
     "stadium": "Ennio Tardini",
     "stadium_capacity": 27906,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        }
-      ],
       "mu": 83,
       "sigma": 11
     }
   },
   {
     "name": "AC Perugia",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Perugia",
     "stadium": "Renato Curi",
     "stadium_capacity": 28000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Laos",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 14
     }
   },
   {
     "name": "Pescara Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Pescara",
     "stadium": "Adriatico",
     "stadium_capacity": 24500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.08
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.08
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.08
-        }
-      ],
       "mu": 59,
       "sigma": 6
     }
   },
   {
     "name": "Piacenza Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Piacenza",
     "stadium": "Leonardo Garilli",
     "stadium_capacity": 21608,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.8
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.04
-        }
-      ],
       "mu": 61,
       "sigma": 20
     }
   },
   {
     "name": "Reggina 1914",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Reggio Calabria",
     "stadium": "Oreste Granillo",
     "stadium_capacity": 27543,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.04
-        },
-        {
-          "name": "Finland",
-          "probability": 0.04
-        }
-      ],
       "mu": 72,
       "sigma": 6
     }
   },
   {
     "name": "AS Roma",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Rome",
     "stadium": "Stadio Olimpico",
     "stadium_capacity": 73261,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.82
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 29
     }
   },
   {
     "name": "US Salernitana",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Salerno",
     "stadium": "Stadio Arechi",
     "stadium_capacity": 31300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.04
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 30
     }
   },
   {
     "name": "Sampdoria",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Genoa",
     "stadium": "Luigi Ferraris",
     "stadium_capacity": 36703,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.85
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 21
     }
   },
   {
     "name": "ACN Siena 1904",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Siena",
     "stadium": "Artemio Franchi",
     "stadium_capacity": 15725,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.79
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 8
     }
   },
   {
     "name": "Ternana Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Terni",
     "stadium": "Libero Liberati",
     "stadium_capacity": 20095,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.76
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.12
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.12
-        }
-      ],
       "mu": 84,
       "sigma": 20
     }
   },
   {
     "name": "Torino",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Torino",
     "stadium": "Stadio Olimpico di Torino",
     "stadium_capacity": 28140,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.9
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 16
     }
   },
   {
     "name": "FC Treviso",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Treviso",
     "stadium": "Omobono Tenni",
     "stadium_capacity": 9996,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.06
-        },
-        {
-          "name": "China",
-          "probability": 0.06
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        }
-      ],
       "mu": 73,
       "sigma": 31
     }
   },
   {
     "name": "Unione Triestina",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Trieste",
     "stadium": "Nereo Rocco",
     "stadium_capacity": 32454,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.88
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 21
     }
   },
   {
     "name": "Udinese Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Udine",
     "stadium": "Friuli",
     "stadium_capacity": 25144,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        }
-      ],
       "mu": 62,
       "sigma": 6
     }
   },
   {
     "name": "Venezia FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Venezia",
     "stadium": "Pierluigi Penzo",
     "stadium_capacity": 9977,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.11
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.11
-        }
-      ],
       "mu": 54,
       "sigma": 9
     }
   },
   {
     "name": "Hellas Verona",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Verona",
     "stadium": "Marcantonio Bentegodi",
     "stadium_capacity": 42160,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        },
-        {
-          "name": "Spain",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 22
     }
   },
   {
     "name": "LR Vicenza",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Vicenza",
     "stadium": "Romeo Menti",
     "stadium_capacity": 12800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.78
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.07
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.07
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 16
     }
   },
   {
     "name": "US Avellino",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Avellino",
     "stadium": "Partenio",
     "stadium_capacity": 26308,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.11
-        },
-        {
-          "name": "Greece",
-          "probability": 0.11
-        }
-      ],
       "mu": 74,
       "sigma": 5
     }
   },
   {
     "name": "SS Juve Stabia",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Castellammare di Stabia",
     "stadium": "Romeo Menti",
     "stadium_capacity": 12800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Laos",
-          "probability": 0.07
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.07
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.07
-        },
-        {
-          "name": "Macao",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 10
     }
   },
   {
     "name": "Novara Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Novara",
     "stadium": "Silvio Piola",
     "stadium_capacity": 17781,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.89
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 28
     }
   },
   {
     "name": "US Sambenedettese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "San Benedetto del Tronto",
     "stadium": "Riviera delle Palme",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.82
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.18
-        }
-      ],
       "mu": 65,
       "sigma": 24
     }
   },
   {
     "name": "ASD Gallipoli",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Gallipoli",
     "stadium": "Antonio Bianco",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.88
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 33
     }
   },
   {
     "name": "USD Cavese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Cava de' Tirreni",
     "stadium": "Simonetta Lamberti",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.15
-        },
-        {
-          "name": "Greece",
-          "probability": 0.15
-        }
-      ],
       "mu": 55,
       "sigma": 28
     }
   },
   {
     "name": "ASD Real Giulianova",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Giulianova",
     "stadium": "Rubens Fadini",
     "stadium_capacity": 5625,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.06
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.06
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        },
-        {
-          "name": "France",
-          "probability": 0.06
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.06
-        }
-      ],
       "mu": 52,
       "sigma": 12
     }
   },
   {
     "name": "Taranto FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Taranto",
     "stadium": "Erasmo Iacovone",
     "stadium_capacity": 27584,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        }
-      ],
       "mu": 70,
       "sigma": 10
     }
   },
   {
     "name": "Ravenna FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Ravenna",
     "stadium": "Bruno Benelli",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.83
-        },
-        {
-          "name": "Canada",
-          "probability": 0.03
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        }
-      ],
       "mu": 68,
       "sigma": 15
     }
   },
   {
     "name": "SS Teramo Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Teramo",
     "stadium": "Gaetano Bonolis",
     "stadium_capacity": 7498,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.74
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.09
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.09
-        },
-        {
-          "name": "Wales",
-          "probability": 0.09
-        }
-      ],
       "mu": 68,
       "sigma": 35
     }
   },
   {
     "name": "Sorrento Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Sorrento",
     "stadium": "Italia",
     "stadium_capacity": 3600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.1
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.1
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.1
-        }
-      ],
       "mu": 69,
       "sigma": 33
     }
   },
   {
     "name": "FC Lumezzane",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lumezzane",
     "stadium": "Tullio Saleri",
     "stadium_capacity": 4150,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.72
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.07
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.07
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.07
-        }
-      ],
       "mu": 46,
       "sigma": 30
     }
   },
   {
     "name": "Potenza SC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Potenza",
     "stadium": "Alfredo Viviani",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.76
-        },
-        {
-          "name": "Togo",
-          "probability": 0.12
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.12
-        }
-      ],
       "mu": 53,
       "sigma": 20
     }
   },
   {
     "name": "Calcio Lecco",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lecco",
     "stadium": "Rigamonti-Ceppi",
     "stadium_capacity": 4977,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.74
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.05
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 34
     }
   },
   {
     "name": "Cosenza Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Cosenza",
     "stadium": "San Vito",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.89
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 34
     }
   },
   {
     "name": "ASD Citt\\u00e0 Di Varese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Varese",
     "stadium": "Franco Ossola",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.16
-        }
-      ],
       "mu": 80,
       "sigma": 32
     }
   },
   {
     "name": "SS Chieti Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Chieti",
     "stadium": "Guido Angelini",
     "stadium_capacity": 12750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.85
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        }
-      ],
       "mu": 71,
       "sigma": 8
     }
   },
   {
     "name": "Carrarese Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Carrara",
     "stadium": "Dei Marmi",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.85
-        },
-        {
-          "name": "Japan",
-          "probability": 0.08
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.08
-        }
-      ],
       "mu": 58,
       "sigma": 7
     }
   },
   {
     "name": "US Latina Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Latina",
     "stadium": "Domenico Francioni",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.85
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 17
     }
   },
   {
     "name": "Carpi",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Carpi",
     "stadium": "Sandro Cabassi",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.88
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        }
-      ],
       "mu": 50,
       "sigma": 23
     }
   },
   {
     "name": "Feralpisal\\u00f2",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Sal\\u00f2 (BS) e Lonato del Garda (BS)",
     "stadium": "Lino Turina",
     "stadium_capacity": 1550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.87
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.07
-        },
-        {
-          "name": "Greece",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 8
     }
   },
   {
     "name": "Virtus Entella",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Chiavari",
     "stadium": "Comunale Chiavari",
     "stadium_capacity": 5535,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.8
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.1
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.1
-        }
-      ],
       "mu": 45,
       "sigma": 34
     }
   },
   {
     "name": "FC Castiglione",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Castiglione delle Stiviere",
     "stadium": "San Pietro",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.79
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.1
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.1
-        }
-      ],
       "mu": 59,
       "sigma": 26
     }
   },
   {
     "name": "HinterReggio Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Reggio Calabria",
     "stadium": "Oreste Granillo",
     "stadium_capacity": 27543,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        }
-      ],
       "mu": 69,
       "sigma": 28
     }
   },
   {
     "name": "Santarcangelo Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Santarcangelo di Romagna",
     "stadium": "Valentino Mazzola",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.73
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.09
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.09
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.09
-        }
-      ],
       "mu": 51,
       "sigma": 33
     }
   },
   {
     "name": "Forl\\u00ec FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Forl\\u00ec",
     "stadium": "Tullo Morgagni",
     "stadium_capacity": 3466,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.12
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.12
-        }
-      ],
       "mu": 82,
       "sigma": 24
     }
   },
   {
     "name": "AC Savoia 1908",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Torre Annunziata",
     "stadium": "Stadio Alfredo Giraud",
     "stadium_capacity": 10750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.74
-        },
-        {
-          "name": "Iran",
-          "probability": 0.26
-        }
-      ],
       "mu": 66,
       "sigma": 23
     }
   },
   {
     "name": "US Agropoli 1921",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Agropoli",
     "stadium": "Stadio Raffaele Guariglia",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.19
-        }
-      ],
       "mu": 51,
       "sigma": 16
     }
   },
   {
     "name": "Terracina Calcio 1925",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Terracina",
     "stadium": "Mario Colavolpe",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Wales",
-          "probability": 0.06
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.06
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 15
     }
   },
   {
     "name": "FC Neapolis",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Mugnano di Napoli",
     "stadium": "Stadio Alberto Vallefuoco",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 31
     }
   },
   {
     "name": "FC Rieti",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Rieti",
     "stadium": "Stadio Centro d'Italia \\u2013 Manlio Scopigno",
     "stadium_capacity": 9980,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 26
     }
   },
   {
     "name": "San Severo",
-    "country": "Italy",
+    "country": "ITA",
     "location": "San Severo",
     "stadium": "Ricciardelli",
     "stadium_capacity": 350,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.9
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 16
     }
   },
   {
     "name": "Aurora Seriate Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Seriate",
     "stadium": "Stadio Comunale",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.89
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Spain",
-          "probability": 0.05
-        }
-      ],
       "mu": 71,
       "sigma": 17
     }
   },
   {
     "name": "ASD Sancolombano",
-    "country": "Italy",
+    "country": "ITA",
     "location": "San Colombano al Lambro",
     "stadium": "Franco Riccardi",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.86
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Angola",
-          "probability": 0.04
-        }
-      ],
       "mu": 63,
       "sigma": 15
     }
   },
   {
     "name": "Borgosesia Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Borgosesia",
     "stadium": "Comunale",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.76
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.12
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.12
-        }
-      ],
       "mu": 58,
       "sigma": 26
     }
   },
   {
     "name": "Sulmona Calcio 1921",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Sulmona",
     "stadium": "Stadio Francesco Pallozzi",
     "stadium_capacity": 1411,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        },
-        {
-          "name": "Spain",
-          "probability": 0.06
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.06
-        }
-      ],
       "mu": 60,
       "sigma": 7
     }
   },
   {
     "name": "Nerostellati Frattese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Frattamaggiore",
     "stadium": "Stadio Comunale Pasquale Ianniello",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        },
-        {
-          "name": "Germany",
-          "probability": 0.07
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.07
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.07
-        }
-      ],
       "mu": 84,
       "sigma": 18
     }
   },
   {
     "name": "ASD Muravera Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Viterbo",
     "stadium": "Stadio Enrico Rocchi",
     "stadium_capacity": 5460,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.73
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.09
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.09
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.09
-        }
-      ],
       "mu": 59,
       "sigma": 33
     }
   },
   {
     "name": "US Folgore Caratese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Carate Brianza",
     "stadium": "Stadio XXV Aprile",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.06
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.06
-        },
-        {
-          "name": "Wales",
-          "probability": 0.06
-        },
-        {
-          "name": "Finland",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 31
     }
   },
   {
     "name": "Virtus Bergamo",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Alzano Lombardo",
     "stadium": "Stadio Carillo Pesenti Pigna",
     "stadium_capacity": 1900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.06
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 29
     }
   },
   {
     "name": "Derthona FCB",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Tortona",
     "stadium": "Stadio Fausto Coppi",
     "stadium_capacity": 2700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.06
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.06
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.06
-        }
-      ],
       "mu": 85,
       "sigma": 26
     }
   },
   {
     "name": "NK Kras Repen",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Repen",
     "stadium": "Stadio comunale di Monrupino",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        }
-      ],
       "mu": 73,
       "sigma": 32
     }
   },
   {
     "name": "ASD Lanusei Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lanusei",
     "stadium": "Campo Comunale Lixius Lanusei",
     "stadium_capacity": 600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.19
-        }
-      ],
       "mu": 62,
       "sigma": 5
     }
   },
   {
     "name": "SS Rende",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Rende",
     "stadium": "Stadio Marco Lorenzon",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.8
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 17
     }
   },
   {
     "name": "Calcio Pomigliano",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Pomigliano d'Arco",
     "stadium": "Stadio Ugo Gobbato",
     "stadium_capacity": 1600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.76
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.05
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.05
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 19
     }
   },
   {
     "name": "Sicula Leonzio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lentini",
     "stadium": "Stadio Angelino Nobile",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.83
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.06
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.06
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        }
-      ],
       "mu": 46,
       "sigma": 28
     }
   },
   {
     "name": "ACD Campodarsego",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Campodarsego",
     "stadium": "Stadio Comunale",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.72
-        },
-        {
-          "name": "Albania",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        },
-        {
-          "name": "Wales",
-          "probability": 0.07
-        },
-        {
-          "name": "Finland",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 30
     }
   },
   {
     "name": "Lentigione Calcio",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lentigione",
     "stadium": "Valente Levantini",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.77
-        },
-        {
-          "name": "Austria",
-          "probability": 0.08
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.08
-        },
-        {
-          "name": "Albania",
-          "probability": 0.08
-        }
-      ],
       "mu": 50,
       "sigma": 16
     }
   },
   {
     "name": "USD Castellazzo",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Castellazzo Bormida",
     "stadium": "Stadio Comunale",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.81
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        }
-      ],
       "mu": 72,
       "sigma": 32
     }
   },
   {
     "name": "ASD Albalonga",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Albano Laziale",
     "stadium": "Stadio Pio XII",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.08
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.08
-        }
-      ],
       "mu": 65,
       "sigma": 27
     }
   },
   {
     "name": "Flaminia Civita Castellana",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Civita Castellana",
     "stadium": "Stadio Turiddu Madami",
     "stadium_capacity": 1800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.8
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.1
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.1
-        }
-      ],
       "mu": 54,
       "sigma": 6
     }
   },
   {
     "name": "Axys Zola",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Zola Predosa",
     "stadium": "Stadio Enrico Filippetti",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 5
     }
   },
   {
     "name": "Franciacorta FC",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Adro",
     "stadium": "CS Comunale",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.84
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 24
     }
   },
   {
     "name": "Vigor Carpaneto",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Carpaneto Piacentino",
     "stadium": "Stadio Carpaneto Piacentino",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.73
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.27
-        }
-      ],
       "mu": 52,
       "sigma": 6
     }
   },
   {
     "name": "ASD Corigliano Calabro",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Corigliano Calabro",
     "stadium": "Citt\\u00e0 di Corigliano",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.15
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.15
-        }
-      ],
       "mu": 51,
       "sigma": 8
     }
   },
   {
     "name": "Giugliano",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Giugliano",
     "stadium": "Stadio Alberto de Cristofaro",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.71
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "England",
-          "probability": 0.06
-        },
-        {
-          "name": "Iran",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        }
-      ],
       "mu": 49,
       "sigma": 14
     }
   },
   {
     "name": "Lamezia Terme",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Lamezia Terme",
     "stadium": "Stadio Guido D'Ippolito",
     "stadium_capacity": 5842,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.75
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.12
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.12
-        }
-      ],
       "mu": 78,
       "sigma": 29
     }
   },
   {
     "name": "FC Matese",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Sepicciano",
     "stadium": "Stadio Pasqualino Ferrante",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.88
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.03
-        },
-        {
-          "name": "Canada",
-          "probability": 0.03
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        }
-      ],
       "mu": 78,
       "sigma": 26
     }
   },
   {
     "name": "San Donato Tavarnelle",
-    "country": "Italy",
+    "country": "ITA",
     "location": "Montevarchi",
     "stadium": "Gastone Brilli Peri",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Italy",
-          "probability": 0.72
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.07
-        },
-        {
-          "name": "Laos",
-          "probability": 0.07
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.07
-        }
-      ],
       "mu": 75,
       "sigma": 26
     }
   },
   {
     "name": "ASEC Mimosas",
-    "country": "Ivory Coast",
+    "country": "CIV",
     "location": "Abidjan",
     "stadium": "F\\u00e9lix Houphou\\u00ebt-Boigny",
     "stadium_capacity": 50000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ivory Coast",
-          "probability": 0.79
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 8
     }
   },
   {
     "name": "Tivoli Gardens",
-    "country": "Jamaica",
+    "country": "JAM",
     "location": "Kingston",
     "stadium": "Edward Seaga",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jamaica",
-          "probability": 0.79
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.07
-        },
-        {
-          "name": "Panama",
-          "probability": 0.07
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.07
-        }
-      ],
       "mu": 55,
       "sigma": 33
     }
   },
   {
     "name": "Portmore United",
-    "country": "Jamaica",
+    "country": "JAM",
     "location": "Portmore",
     "stadium": "Ferdi Neita Sports Complex",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jamaica",
-          "probability": 0.71
-        },
-        {
-          "name": "China",
-          "probability": 0.06
-        },
-        {
-          "name": "Iran",
-          "probability": 0.06
-        },
-        {
-          "name": "Laos",
-          "probability": 0.06
-        },
-        {
-          "name": "Israel",
-          "probability": 0.06
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        }
-      ],
       "mu": 66,
       "sigma": 23
     }
   },
   {
     "name": "Rivoli United",
-    "country": "Jamaica",
+    "country": "JAM",
     "location": "Ewarton",
     "stadium": "Prison Oval",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jamaica",
-          "probability": 0.9
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.02
-        },
-        {
-          "name": "India",
-          "probability": 0.02
-        },
-        {
-          "name": "Italy",
-          "probability": 0.02
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.02
-        }
-      ],
       "mu": 49,
       "sigma": 9
     }
   },
   {
     "name": "Sporting Central Academy",
-    "country": "Jamaica",
+    "country": "JAM",
     "location": "Clarendon",
     "stadium": "Juici Patties Park",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jamaica",
-          "probability": 0.89
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 7
     }
   },
   {
     "name": "Cavalier FC",
-    "country": "Jamaica",
+    "country": "JAM",
     "location": "Kingston",
     "stadium": "Stadium East Field",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jamaica",
-          "probability": 0.89
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        }
-      ],
       "mu": 77,
       "sigma": 8
     }
   },
   {
     "name": "Yokohama F. Marinos",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Yokohama",
     "stadium": "Nissan Stadium",
     "stadium_capacity": 72327,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.8
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 21
     }
   },
   {
     "name": "Gamba Osaka",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Osaka",
     "stadium": "Suita City Football Stadium",
     "stadium_capacity": 39694,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.84
-        },
-        {
-          "name": "France",
-          "probability": 0.03
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.03
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.03
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.03
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 32
     }
   },
   {
     "name": "Kashima Antlers",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Kashima",
     "stadium": "Kashima Stadium",
     "stadium_capacity": 40728,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.79
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        }
-      ],
       "mu": 79,
       "sigma": 26
     }
   },
   {
     "name": "Shimizu S-Pulse",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Shizuoka",
     "stadium": "IAI Stadium Nihondaira",
     "stadium_capacity": 20248,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.89
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Albania",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 16
     }
   },
   {
     "name": "FC Tokyo",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Tokyo",
     "stadium": "Ajinomoto Stadium",
     "stadium_capacity": 50000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.84
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.03
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.03
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.03
-        }
-      ],
       "mu": 71,
       "sigma": 15
     }
   },
   {
     "name": "Omiya Ardija",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Saitama",
     "stadium": "Omiya Park Stadium",
     "stadium_capacity": 15500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.8
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 16
     }
   },
   {
     "name": "Ventforet Kofu",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Kofu",
     "stadium": "Kose Sports Stadium",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.71
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.15
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.15
-        }
-      ],
       "mu": 79,
       "sigma": 15
     }
   },
   {
     "name": "Kyoto Sanga",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Kyoto",
     "stadium": "Nishikyogoku",
     "stadium_capacity": 20389,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.83
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.09
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.09
-        }
-      ],
       "mu": 69,
       "sigma": 32
     }
   },
   {
     "name": "Avispa Fukuoka",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Fukuoka",
     "stadium": "Hakata No Mori Stadium",
     "stadium_capacity": 22563,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.84
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        }
-      ],
       "mu": 62,
       "sigma": 11
     }
   },
   {
     "name": "Yokohama FC",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Yokohama",
     "stadium": "Yokohama Mitsuzawa",
     "stadium_capacity": 15046,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.77
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.23
-        }
-      ],
       "mu": 46,
       "sigma": 10
     }
   },
   {
     "name": "Tokushima Vortis",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Tokushima",
     "stadium": "Naruto Athletic Stadium",
     "stadium_capacity": 20441,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.82
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 26
     }
   },
   {
     "name": "Gainare Tottori",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Yonago",
     "stadium": "Tottori Bank Bird",
     "stadium_capacity": 16033,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.89
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.02
-        },
-        {
-          "name": "Wales",
-          "probability": 0.02
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.02
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.02
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.02
-        }
-      ],
       "mu": 79,
       "sigma": 31
     }
   },
   {
     "name": "FC Gifu",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Gifu",
     "stadium": "Gifu Nagaragawa Stadium",
     "stadium_capacity": 31000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.81
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 31
     }
   },
   {
     "name": "Ehime FC",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Matsuyama",
     "stadium": "Ningineer Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.86
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 23
     }
   },
   {
     "name": "Roasso Kumamoto",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Kumamoto",
     "stadium": "Kumamoto Athletics Stadium",
     "stadium_capacity": 32000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.78
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 35
     }
   },
   {
     "name": "Thespakusatsu Gunma",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Gunma",
     "stadium": "Shoda Shoyu Stadium",
     "stadium_capacity": 10050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.84
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.08
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.08
-        }
-      ],
       "mu": 70,
       "sigma": 7
     }
   },
   {
     "name": "SC Sagamihara",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Sagamihara",
     "stadium": "Sagamihara Asamizo Park Stadium",
     "stadium_capacity": 11808,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.79
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.21
-        }
-      ],
       "mu": 57,
       "sigma": 16
     }
   },
   {
     "name": "Nara Club",
-    "country": "Japan",
+    "country": "JPN",
     "location": "Nara",
     "stadium": "Rohto Field Nara",
     "stadium_capacity": 36000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Japan",
-          "probability": 0.89
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 6
     }
   },
   {
     "name": "Al Faisaly",
-    "country": "Jordan",
+    "country": "JOR",
     "location": "Amman",
     "stadium": "Amman International",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Jordan",
-          "probability": 0.9
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.1
-        }
-      ],
       "mu": 77,
       "sigma": 28
     }
   },
   {
     "name": "FK Aktobe",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Aktobe",
     "stadium": "Aktobe Central Stadium",
     "stadium_capacity": 13500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.75
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.25
-        }
-      ],
       "mu": 67,
       "sigma": 24
     }
   },
   {
     "name": "Shakhter Karagandy",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Karagandy",
     "stadium": "Shakhter",
     "stadium_capacity": 19500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.74
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.26
-        }
-      ],
       "mu": 75,
       "sigma": 25
     }
   },
   {
     "name": "FC Ordabasy",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Shymkent",
     "stadium": "Kazhimukan Munaitpasov",
     "stadium_capacity": 37000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.86
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.14
-        }
-      ],
       "mu": 70,
       "sigma": 34
     }
   },
   {
     "name": "FC Vostok",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Oskemen",
     "stadium": "Vostok Stadium",
     "stadium_capacity": 8500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.77
-        },
-        {
-          "name": "China",
-          "probability": 0.08
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.08
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.08
-        }
-      ],
       "mu": 79,
       "sigma": 11
     }
   },
   {
     "name": "Okzhetpes Kokshetau",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Kokshetau",
     "stadium": "Astana Arena",
     "stadium_capacity": 30244,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.87
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.07
-        }
-      ],
       "mu": 75,
       "sigma": 33
     }
   },
   {
     "name": "FC Kyran",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Shymkent",
     "stadium": "Stadion Lokomotiv",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.89
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.11
-        }
-      ],
       "mu": 58,
       "sigma": 8
     }
   },
   {
     "name": "FK Turan",
-    "country": "Kazakhstan",
+    "country": "KAZ",
     "location": "Arys",
     "stadium": "Turkestan Arena",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kazakhstan",
-          "probability": 0.75
-        },
-        {
-          "name": "Austria",
-          "probability": 0.08
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.08
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.08
-        }
-      ],
       "mu": 66,
       "sigma": 7
     }
   },
   {
     "name": "Ulsan Hyundai",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Ulsan",
     "stadium": "Big Crown",
     "stadium_capacity": 44466,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.83
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.09
-        },
-        {
-          "name": "Wales",
-          "probability": 0.09
-        }
-      ],
       "mu": 65,
       "sigma": 8
     }
   },
   {
     "name": "Pohang Steelers",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Pohang",
     "stadium": "Steelyard",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.86
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        }
-      ],
       "mu": 82,
       "sigma": 6
     }
   },
   {
     "name": "Daejeon Citizen",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Daejeon",
     "stadium": "Purple Arena",
     "stadium_capacity": 41295,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.79
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.1
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.1
-        }
-      ],
       "mu": 46,
       "sigma": 22
     }
   },
   {
     "name": "Jeju United",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Seogwipo",
     "stadium": "Seogwipo",
     "stadium_capacity": 42256,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.78
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 24
     }
   },
   {
     "name": "Gwangju FC",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Gwangju",
     "stadium": "Guus Hiddink Stadium",
     "stadium_capacity": 44118,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.72
-        },
-        {
-          "name": "Chile",
-          "probability": 0.28
-        }
-      ],
       "mu": 53,
       "sigma": 11
     }
   },
   {
     "name": "Gimpo FC",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Gimpo",
     "stadium": "Gimpo Stadium",
     "stadium_capacity": 5068,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.76
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.12
-        },
-        {
-          "name": "Finland",
-          "probability": 0.12
-        }
-      ],
       "mu": 78,
       "sigma": 11
     }
   },
   {
     "name": "Daejeon Korail FC",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Daejeon",
     "stadium": "Daejeon Hanbat Sports Complex",
     "stadium_capacity": 17371,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.81
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.05
-        }
-      ],
       "mu": 67,
       "sigma": 22
     }
   },
   {
     "name": "Ansan Greeners",
-    "country": "Korea Republic",
+    "country": "KOR",
     "location": "Ansan",
     "stadium": "Ansan Wa~ Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Korea Republic",
-          "probability": 0.89
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 8
     }
   },
   {
     "name": "KF Feronikeli",
-    "country": "Kosovo",
+    "country": "KOS",
     "location": "Glogovac",
     "stadium": "Rexhep Rexhepi Stadium",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kosovo",
-          "probability": 0.84
-        },
-        {
-          "name": "Oman",
-          "probability": 0.03
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 10
     }
   },
   {
     "name": "Kuwait SC",
-    "country": "Kuwait",
+    "country": "KUW",
     "location": "Kaifan",
     "stadium": "Al Kuwait Kaifan Stadium",
     "stadium_capacity": 18500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kuwait",
-          "probability": 0.89
-        },
-        {
-          "name": "Albania",
-          "probability": 0.02
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.02
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.02
-        },
-        {
-          "name": "Austria",
-          "probability": 0.02
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.02
-        }
-      ],
       "mu": 67,
       "sigma": 21
     }
   },
   {
     "name": "Khaitan SC",
-    "country": "Kuwait",
+    "country": "KUW",
     "location": "Kuwait City",
     "stadium": "Khaitan Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kuwait",
-          "probability": 0.76
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.06
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        }
-      ],
       "mu": 55,
       "sigma": 29
     }
   },
   {
     "name": "Al Qadsia SC",
-    "country": "Kuwait",
+    "country": "KUW",
     "location": "Kuwait City",
     "stadium": "Mohammed Al-Hamad Stadium",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kuwait",
-          "probability": 0.79
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 7
     }
   },
   {
     "name": "Al Tadamon SC",
-    "country": "Kuwait",
+    "country": "KUW",
     "location": "Al Farwaniyah",
     "stadium": "Al Farwaniyah Stadium",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kuwait",
-          "probability": 0.73
-        },
-        {
-          "name": "United States",
-          "probability": 0.07
-        },
-        {
-          "name": "China",
-          "probability": 0.07
-        },
-        {
-          "name": "Germany",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        }
-      ],
       "mu": 60,
       "sigma": 12
     }
   },
   {
     "name": "FK Neftchi Kochkor-Ata",
-    "country": "Kyrgyzstan",
+    "country": "KGZ",
     "location": "Kochkor-Ata",
     "stadium": "Stadion Neftyannik Kochkor-Ata",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.79
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 35
     }
   },
   {
     "name": "FK Abdysh-Ata Kant",
-    "country": "Kyrgyzstan",
+    "country": "KGZ",
     "location": "Kant",
     "stadium": "Stadion Sportkompleks Abdysh-Ata",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.73
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.27
-        }
-      ],
       "mu": 80,
       "sigma": 7
     }
   },
   {
     "name": "FK Kaganat Osh",
-    "country": "Kyrgyzstan",
+    "country": "KGZ",
     "location": "Osh",
     "stadium": "Suyumbayev Stadion",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.77
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.08
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.08
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.08
-        }
-      ],
       "mu": 47,
       "sigma": 21
     }
   },
   {
     "name": "FK Nur-Batken",
-    "country": "Kyrgyzstan",
+    "country": "KGZ",
     "location": "Batken",
     "stadium": "Zentralny Stadion",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.73
-        },
-        {
-          "name": "France",
-          "probability": 0.07
-        },
-        {
-          "name": "Malta",
-          "probability": 0.07
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        },
-        {
-          "name": "Romania",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 21
     }
@@ -25259,19466 +9565,7376 @@
     "stadium": "New Laos National Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Laos",
-          "probability": 0.71
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        },
-        {
-          "name": "Albania",
-          "probability": 0.07
-        },
-        {
-          "name": "Russia",
-          "probability": 0.07
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.07
-        }
-      ],
       "mu": 48,
       "sigma": 8
     }
   },
   {
     "name": "FK Ventspils",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Ventspils",
     "stadium": "Ventspils Olimpiskais",
     "stadium_capacity": 3200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.77
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.08
-        },
-        {
-          "name": "France",
-          "probability": 0.08
-        },
-        {
-          "name": "Angola",
-          "probability": 0.08
-        }
-      ],
       "mu": 57,
       "sigma": 18
     }
   },
   {
     "name": "Dinaburg FC",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Daugavpils",
     "stadium": "Celtnieks",
     "stadium_capacity": 4100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.85
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.15
-        }
-      ],
       "mu": 84,
       "sigma": 21
     }
   },
   {
     "name": "BFC Daugavpils",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Daugavpils",
     "stadium": "Celtnieks",
     "stadium_capacity": 4100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.86
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.05
-        }
-      ],
       "mu": 50,
       "sigma": 19
     }
   },
   {
     "name": "Rigas Futbola Skola",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Riga",
     "stadium": "NSB Ark\\u0101dija",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.83
-        },
-        {
-          "name": "Norway",
-          "probability": 0.09
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.09
-        }
-      ],
       "mu": 45,
       "sigma": 32
     }
   },
   {
     "name": "SK Babite",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Babite",
     "stadium": "Pi\\u0146\\u0137u stadions",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.83
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 8
     }
   },
   {
     "name": "SK Super Nova",
-    "country": "Latvia",
+    "country": "LVA",
     "location": "Olaine",
     "stadium": "Olaines Pilsetas Stadions",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Latvia",
-          "probability": 0.89
-        },
-        {
-          "name": "India",
-          "probability": 0.02
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.02
-        },
-        {
-          "name": "England",
-          "probability": 0.02
-        },
-        {
-          "name": "Poland",
-          "probability": 0.02
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.02
-        }
-      ],
       "mu": 67,
       "sigma": 32
     }
   },
   {
     "name": "FC Vaduz",
-    "country": "Liechtenstein",
+    "country": "LIE",
     "location": "Vaduz",
     "stadium": "Rheinpark Stadion",
     "stadium_capacity": 6127,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Liechtenstein",
-          "probability": 0.76
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.24
-        }
-      ],
       "mu": 53,
       "sigma": 23
     }
   },
   {
     "name": "FK \\u017dalgiris Vilnius",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Vilnius",
     "stadium": "LFF Stadium",
     "stadium_capacity": 5900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.75
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.08
-        },
-        {
-          "name": "United States",
-          "probability": 0.08
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.08
-        }
-      ],
       "mu": 67,
       "sigma": 28
     }
   },
   {
     "name": "FK Ekranas",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Panev\\u0117\\u017eys",
     "stadium": "Auk\\u0161taitija Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.86
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.14
-        }
-      ],
       "mu": 74,
       "sigma": 33
     }
   },
   {
     "name": "FK Atlantas",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Klaip\\u0117da",
     "stadium": "Klaip\\u0117da Central Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.86
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.07
-        },
-        {
-          "name": "Albania",
-          "probability": 0.07
-        }
-      ],
       "mu": 85,
       "sigma": 33
     }
   },
   {
     "name": "FK Tauras",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Taurag\\u0117",
     "stadium": "Vytautas",
     "stadium_capacity": 1600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.81
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        }
-      ],
       "mu": 46,
       "sigma": 31
     }
   },
   {
     "name": "FK REO Vilnius",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Vilnius",
     "stadium": "\\u017dalgiris Stadium",
     "stadium_capacity": 15030,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.76
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.06
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        }
-      ],
       "mu": 84,
       "sigma": 32
     }
   },
   {
     "name": "FK Nev\\u0117\\u017eis",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "K\\u0117dainiai",
     "stadium": "K\\u0117dainiai Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.75
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.25
-        }
-      ],
       "mu": 71,
       "sigma": 30
     }
   },
   {
     "name": "FK Klaip\\u0117dos Granitas",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Klaip\\u0117da",
     "stadium": "Klaip\\u0117da Central Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.87
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        },
-        {
-          "name": "Italy",
-          "probability": 0.03
-        }
-      ],
       "mu": 53,
       "sigma": 23
     }
   },
   {
     "name": "FK Lokomotyvas",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Radvili\\u0161kis",
     "stadium": "Radvili\\u0161kis Stadium",
     "stadium_capacity": 482,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.73
-        },
-        {
-          "name": "Togo",
-          "probability": 0.14
-        },
-        {
-          "name": "Italy",
-          "probability": 0.14
-        }
-      ],
       "mu": 66,
       "sigma": 28
     }
   },
   {
     "name": "FC Stumbras Kaunas",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Kaunas",
     "stadium": "NFA Stadium",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.72
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.09
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.09
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.09
-        }
-      ],
       "mu": 49,
       "sigma": 11
     }
   },
   {
     "name": "Hegelmann Litauen",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Kaunas",
     "stadium": "NFA Stadium",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.89
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        }
-      ],
       "mu": 82,
       "sigma": 9
     }
   },
   {
     "name": "FC D\\u017eiugas Tel\\u0161iai",
-    "country": "Lithuania",
+    "country": "LTU",
     "location": "Tel\\u0161iai",
     "stadium": "Tel\\u0161iai City Central Stadium",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Lithuania",
-          "probability": 0.72
-        },
-        {
-          "name": "Romania",
-          "probability": 0.07
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        }
-      ],
       "mu": 58,
       "sigma": 29
     }
   },
   {
     "name": "F91 Dudelange",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Dudelange",
     "stadium": "Jos Nosbaum",
     "stadium_capacity": 2600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.8
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.07
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.07
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.07
-        }
-      ],
       "mu": 84,
       "sigma": 15
     }
   },
   {
     "name": "Racing FC UL",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Luxembourg City",
     "stadium": "Achille Hammerel",
     "stadium_capacity": 5814,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.79
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.1
-        },
-        {
-          "name": "India",
-          "probability": 0.1
-        }
-      ],
       "mu": 78,
       "sigma": 16
     }
   },
   {
     "name": "FC Jeunesse Canach",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Canach",
     "stadium": "Stade Rue de Lenningen",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.76
-        },
-        {
-          "name": "Spain",
-          "probability": 0.08
-        },
-        {
-          "name": "Angola",
-          "probability": 0.08
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.08
-        }
-      ],
       "mu": 57,
       "sigma": 21
     }
   },
   {
     "name": "US Mondorf-les-Bains",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Mondorf-les-Bains",
     "stadium": "Achille Hammerel",
     "stadium_capacity": 5814,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.88
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.06
-        }
-      ],
       "mu": 62,
       "sigma": 24
     }
   },
   {
     "name": "US Hostert",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Hostert",
     "stadium": "Stade Jos Becker",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.88
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.04
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        }
-      ],
       "mu": 71,
       "sigma": 17
     }
   },
   {
     "name": "Minerva Lintgen",
-    "country": "Luxembourg",
+    "country": "LUX",
     "location": "Lintgen",
     "stadium": "Stade Jean Donnersbach",
     "stadium_capacity": 1700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Luxembourg",
-          "probability": 0.79
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.04
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 8
     }
   },
   {
     "name": "Sporting Clube de Macau",
-    "country": "Macao",
+    "country": "MAC",
     "location": "Nossa Senhora de F\\u00e1tima",
     "stadium": "Lin Fong Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Macao",
-          "probability": 0.9
-        },
-        {
-          "name": "China",
-          "probability": 0.1
-        }
-      ],
       "mu": 74,
       "sigma": 27
     }
   },
   {
     "name": "Kedah FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kedah",
     "stadium": "Darul Aman Stadium",
     "stadium_capacity": 32387,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.72
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.07
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.07
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.07
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.07
-        }
-      ],
       "mu": 46,
       "sigma": 14
     }
   },
   {
     "name": "Negeri Sembilan FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Seremban",
     "stadium": "Tuanku Abdul Rahman",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.89
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.03
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Romania",
-          "probability": 0.03
-        }
-      ],
       "mu": 65,
       "sigma": 29
     }
   },
   {
     "name": "Kelantan FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kota Bharu",
     "stadium": "Sultan Mohammad IV Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.81
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.05
-        },
-        {
-          "name": "Japan",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 30
     }
   },
   {
     "name": "Harimau Muda",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Yishun",
     "stadium": "City Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.74
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.26
-        }
-      ],
       "mu": 66,
       "sigma": 6
     }
   },
   {
     "name": "FELDA United",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Jengka",
     "stadium": "Tun Abdul Razak Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.89
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.11
-        }
-      ],
       "mu": 64,
       "sigma": 10
     }
   },
   {
     "name": "Johor FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Johor Bahru",
     "stadium": "Stadium Larkin",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.84
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.03
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        }
-      ],
       "mu": 62,
       "sigma": 18
     }
   },
   {
     "name": "Pahang FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kuantan",
     "stadium": "Darulmakmur Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.89
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.03
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.03
-        }
-      ],
       "mu": 57,
       "sigma": 31
     }
   },
   {
     "name": "Terengganu II",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kuala Terengganu",
     "stadium": "Sultan Mizan Zainal Abidin",
     "stadium_capacity": 50000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.86
-        },
-        {
-          "name": "Poland",
-          "probability": 0.14
-        }
-      ],
       "mu": 58,
       "sigma": 6
     }
   },
   {
     "name": "Sime Darby",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kuala Lumpur",
     "stadium": "Majlis Perbandaran Selayang Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.71
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.06
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.06
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 27
     }
   },
   {
     "name": "Kuantan FA",
-    "country": "Malaysia",
+    "country": "MAS",
     "location": "Kuantan",
     "stadium": "Darulmakmur Stadium",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malaysia",
-          "probability": 0.87
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.13
-        }
-      ],
       "mu": 64,
       "sigma": 15
     }
   },
   {
     "name": "New Radiant SC",
-    "country": "Maldives",
+    "country": "MDV",
     "location": "Mal\\u00e9",
     "stadium": "Rasmee Dhandu Stadium",
     "stadium_capacity": 11850,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Maldives",
-          "probability": 0.86
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 35
     }
   },
   {
     "name": "Maziya S&RC",
-    "country": "Maldives",
+    "country": "MDV",
     "location": "Mal\\u00e9",
     "stadium": "Rasmee Dhandu Stadium",
     "stadium_capacity": 11850,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Maldives",
-          "probability": 0.83
-        },
-        {
-          "name": "Chile",
-          "probability": 0.03
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.03
-        }
-      ],
       "mu": 53,
       "sigma": 13
     }
   },
   {
     "name": "Birkirkara",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Birkirkara",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.76
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.06
-        }
-      ],
       "mu": 50,
       "sigma": 8
     }
   },
   {
     "name": "Floriana",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Floriana",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.9
-        },
-        {
-          "name": "Canada",
-          "probability": 0.02
-        },
-        {
-          "name": "Romania",
-          "probability": 0.02
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.02
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.02
-        }
-      ],
       "mu": 68,
       "sigma": 23
     }
   },
   {
     "name": "Hamrun Spartans",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Hamrun",
     "stadium": "Victor Tedesco Stadium",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.75
-        },
-        {
-          "name": "Germany",
-          "probability": 0.25
-        }
-      ],
       "mu": 54,
       "sigma": 15
     }
   },
   {
     "name": "Hibernians FC",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Paola",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.74
-        },
-        {
-          "name": "Chile",
-          "probability": 0.13
-        },
-        {
-          "name": "India",
-          "probability": 0.13
-        }
-      ],
       "mu": 60,
       "sigma": 22
     }
   },
   {
     "name": "Marsaxlokk",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Marsaxlokk",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.82
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.09
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.09
-        }
-      ],
       "mu": 74,
       "sigma": 10
     }
   },
   {
     "name": "Msida St. Joseph",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Msida",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.72
-        },
-        {
-          "name": "Finland",
-          "probability": 0.06
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Russia",
-          "probability": 0.06
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.06
-        },
-        {
-          "name": "India",
-          "probability": 0.06
-        }
-      ],
       "mu": 55,
       "sigma": 6
     }
   },
   {
     "name": "Balzan FC",
-    "country": "Malta",
+    "country": "MLT",
     "location": "\\u0126al Balzan",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.77
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.11
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.11
-        }
-      ],
       "mu": 72,
       "sigma": 12
     }
   },
   {
     "name": "Naxxar Lions",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Naxxar",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.87
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        }
-      ],
       "mu": 51,
       "sigma": 13
     }
   },
   {
     "name": "Zebbug Rangers",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Haz-Zebbug",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.77
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.11
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.11
-        }
-      ],
       "mu": 80,
       "sigma": 30
     }
   },
   {
     "name": "Lija Athletic",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Lija",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.88
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.06
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 11
     }
   },
   {
     "name": "Fgura United",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Fgura",
     "stadium": "MFA Centenary Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.87
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        }
-      ],
       "mu": 55,
       "sigma": 23
     }
   },
   {
     "name": "Zurrieq FC",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Ta' Qali",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.84
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.08
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.08
-        }
-      ],
       "mu": 45,
       "sigma": 27
     }
   },
   {
     "name": "St. George's FC",
-    "country": "Malta",
+    "country": "MLT",
     "location": "Cospicua",
     "stadium": "Ta Qali",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Malta",
-          "probability": 0.85
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.08
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.08
-        }
-      ],
       "mu": 53,
       "sigma": 7
     }
   },
   {
     "name": "Atlas",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Guadalajara",
     "stadium": "Jalisco",
     "stadium_capacity": 62384,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.74
-        },
-        {
-          "name": "Wales",
-          "probability": 0.07
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.07
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.07
-        },
-        {
-          "name": "Canada",
-          "probability": 0.07
-        }
-      ],
       "mu": 60,
       "sigma": 31
     }
   },
   {
     "name": "Chiapas FC",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Tuxtla Guti\\u00e9rrez",
     "stadium": "Victor Manuel Reyna",
     "stadium_capacity": 27500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.71
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.07
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.07
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.07
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.07
-        }
-      ],
       "mu": 47,
       "sigma": 33
     }
   },
   {
     "name": "Monterrey",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Monterrey",
     "stadium": "Estadio BBVA Bancomer",
     "stadium_capacity": 52237,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.77
-        },
-        {
-          "name": "England",
-          "probability": 0.23
-        }
-      ],
       "mu": 84,
       "sigma": 7
     }
   },
   {
     "name": "Santos Laguna",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Torre\\u00f3n",
     "stadium": "Estadio Corona",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.83
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.17
-        }
-      ],
       "mu": 52,
       "sigma": 11
     }
   },
   {
     "name": "Club Quer\\u00e9taro",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Santiago de Quer\\u00e9taro",
     "stadium": "La Corregidora",
     "stadium_capacity": 45575,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.89
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.03
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.03
-        },
-        {
-          "name": "Norway",
-          "probability": 0.03
-        }
-      ],
       "mu": 62,
       "sigma": 25
     }
   },
   {
     "name": "Club Puebla",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Puebla",
     "stadium": "Cuauhtemoc",
     "stadium_capacity": 45396,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.77
-        },
-        {
-          "name": "Iran",
-          "probability": 0.11
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.11
-        }
-      ],
       "mu": 61,
       "sigma": 24
     }
   },
   {
     "name": "M\\u00e9rida",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "M\\u00e9rida",
     "stadium": "Carlos Iturralde",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.89
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 19
     }
   },
   {
     "name": "Atl\\u00e9tico Morelia",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Morelia",
     "stadium": "Estadio Morelos Morelia",
     "stadium_capacity": 41500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.89
-        },
-        {
-          "name": "Norway",
-          "probability": 0.11
-        }
-      ],
       "mu": 64,
       "sigma": 8
     }
   },
   {
     "name": "FC Ju\\u00e1rez",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Chihuahua",
     "stadium": "Benito Ju\\u00e1rez",
     "stadium_capacity": 22300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.87
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        },
-        {
-          "name": "Chile",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 34
     }
   },
   {
     "name": "Potros UAEM",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Toluca",
     "stadium": "Estadio Universitario Alberto 'Chivo' C\\u00f3r",
     "stadium_capacity": 32000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.84
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 26
     }
   },
   {
     "name": "Pioneros de Canc\\u00fan",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Canc\\u00fan",
     "stadium": "Estadio Canc\\u00fan 86",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.82
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.18
-        }
-      ],
       "mu": 62,
       "sigma": 31
     }
   },
   {
     "name": "CD Tapat\\u00edo",
-    "country": "Mexico",
+    "country": "MEX",
     "location": "Guadalajara",
     "stadium": "Akron",
     "stadium_capacity": 49850,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mexico",
-          "probability": 0.88
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.04
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.04
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 24
     }
   },
   {
     "name": "Dacia Chi\\u015fin\\u0103u",
-    "country": "Moldova",
+    "country": "MDA",
     "location": "Chi\\u015fin\\u0103u",
     "stadium": "Sheriff Smal Arena",
     "stadium_capacity": 10500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Moldova",
-          "probability": 0.77
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.23
-        }
-      ],
       "mu": 58,
       "sigma": 34
     }
   },
   {
     "name": "FC Tiraspol",
-    "country": "Moldova",
+    "country": "MDA",
     "location": "Tiraspol",
     "stadium": "Sheriff Stadium",
     "stadium_capacity": 14300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Moldova",
-          "probability": 0.79
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 7
     }
   },
   {
     "name": "Dinamo-Auto Tiraspol",
-    "country": "Moldova",
+    "country": "MDA",
     "location": "Tiraspol",
     "stadium": "Dinamo-Auto",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Moldova",
-          "probability": 0.71
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.15
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.15
-        }
-      ],
       "mu": 55,
       "sigma": 30
     }
   },
   {
     "name": "Victoria Bardar",
-    "country": "Moldova",
+    "country": "MDA",
     "location": "Bardar",
     "stadium": "CSCT Buiucani",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Moldova",
-          "probability": 0.81
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.04
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 19
     }
   },
   {
     "name": "Ulaanbaatar City",
-    "country": "Mongolia",
+    "country": "MNG",
     "location": "Ulaanbaatar",
     "stadium": "G-Mobile Arena",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mongolia",
-          "probability": 0.79
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.1
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 20
     }
   },
   {
     "name": "OFK Petrovac",
-    "country": "Montenegro",
+    "country": "MNE",
     "location": "Petrovac",
     "stadium": "Pod Malim Brdom",
     "stadium_capacity": 530,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Montenegro",
-          "probability": 0.72
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.28
-        }
-      ],
       "mu": 45,
       "sigma": 13
     }
   },
   {
     "name": "FK Sutjeska",
-    "country": "Montenegro",
+    "country": "MNE",
     "location": "Nik\\u0161i\\u0107",
     "stadium": "Kraj Bistrice",
     "stadium_capacity": 10800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Montenegro",
-          "probability": 0.85
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.04
-        },
-        {
-          "name": "Norway",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        }
-      ],
       "mu": 84,
       "sigma": 18
     }
   },
   {
     "name": "FK Jedinstvo",
-    "country": "Montenegro",
+    "country": "MNE",
     "location": "Bijelo Polje",
     "stadium": "Gradski Stadium (Bijelo Polje)",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Montenegro",
-          "probability": 0.87
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.13
-        }
-      ],
       "mu": 66,
       "sigma": 31
     }
   },
   {
     "name": "FK Bokelj",
-    "country": "Montenegro",
+    "country": "MNE",
     "location": "Kotor",
     "stadium": "Pod Vrmcem",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Montenegro",
-          "probability": 0.71
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.1
-        },
-        {
-          "name": "Finland",
-          "probability": 0.1
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "Raja Casablanca",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Casablanca",
     "stadium": "Stade Mohammed V",
     "stadium_capacity": 67000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.9
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 13
     }
   },
   {
     "name": "Difaa El Jadida",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "El Jadida",
     "stadium": "Stade El Abdi",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.77
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 14
     }
   },
   {
     "name": "Moghreb T\\u00e9touan",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "T\\u00e9touan",
     "stadium": "Saniat Rmel",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.85
-        },
-        {
-          "name": "Albania",
-          "probability": 0.15
-        }
-      ],
       "mu": 57,
       "sigma": 12
     }
   },
   {
     "name": "RS Berkane",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Berkane",
     "stadium": "Stade municipal de Berkane",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.81
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.09
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.09
-        }
-      ],
       "mu": 85,
       "sigma": 8
     }
   },
   {
     "name": "Chabab Rif Al Hoceima",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Al Hoceima",
     "stadium": "Mimoun Al Arsi",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.75
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.05
-        }
-      ],
       "mu": 57,
       "sigma": 14
     }
   },
   {
     "name": "Hassania d'Agadir",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Agadir",
     "stadium": "Stade Adrar Agadir",
     "stadium_capacity": 45480,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.74
-        },
-        {
-          "name": "Spain",
-          "probability": 0.09
-        },
-        {
-          "name": "Iran",
-          "probability": 0.09
-        },
-        {
-          "name": "Italy",
-          "probability": 0.09
-        }
-      ],
       "mu": 75,
       "sigma": 23
     }
   },
   {
     "name": "KAC K\\u00e9nitra",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "K\\u00e9nitra",
     "stadium": "Stade Municipal de Kenitra",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.72
-        },
-        {
-          "name": "Macao",
-          "probability": 0.28
-        }
-      ],
       "mu": 46,
       "sigma": 8
     }
   },
   {
     "name": "AS Sal\\u00e9",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Sal\\u00e9",
     "stadium": "Stade Boubker Ammar",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.89
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "Rapide Oued Zem",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Oued Zem",
     "stadium": "Stade Municipal",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.75
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.08
-        },
-        {
-          "name": "Iran",
-          "probability": 0.08
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.08
-        }
-      ],
       "mu": 50,
       "sigma": 25
     }
   },
   {
     "name": "Racing de Casablanca",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Casablanca",
     "stadium": "Stade P\\u00e8re J\\u00e9go",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.73
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 30
     }
   },
   {
     "name": "Union de Touarga",
-    "country": "Morocco",
+    "country": "MAR",
     "location": "Rabat",
     "stadium": "Terrain Filine",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Morocco",
-          "probability": 0.83
-        },
-        {
-          "name": "Albania",
-          "probability": 0.09
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.09
-        }
-      ],
       "mu": 47,
       "sigma": 25
     }
   },
   {
     "name": "Ferroviario de Maputo",
-    "country": "Mozambique",
+    "country": "MOZ",
     "location": "Maputo",
     "stadium": "Estadio da Machava",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Mozambique",
-          "probability": 0.9
-        },
-        {
-          "name": "Macao",
-          "probability": 0.02
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.02
-        },
-        {
-          "name": "Oman",
-          "probability": 0.02
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.02
-        },
-        {
-          "name": "Albania",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 31
     }
   },
   {
     "name": "ADO Den Haag",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "The Hague",
     "stadium": "Cars Jeans Stadion",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.78
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        },
-        {
-          "name": "Italy",
-          "probability": 0.04
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.04
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 13
     }
   },
   {
     "name": "AGOVV Apeldoorn",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Apeldoorn",
     "stadium": "Sportpark Berg en Bos",
     "stadium_capacity": 2800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.71
-        },
-        {
-          "name": "Norway",
-          "probability": 0.07
-        },
-        {
-          "name": "Australia",
-          "probability": 0.07
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.07
-        },
-        {
-          "name": "Germany",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 16
     }
   },
   {
     "name": "AZ Alkmaar",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Alkmaar",
     "stadium": "AFAS Stadion",
     "stadium_capacity": 17023,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.09
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.09
-        }
-      ],
       "mu": 50,
       "sigma": 23
     }
   },
   {
     "name": "Ajax",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Amsterdam",
     "stadium": "Johan Cruyff Arena",
     "stadium_capacity": 54033,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.85
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.03
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.03
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        }
-      ],
       "mu": 82,
       "sigma": 10
     }
   },
   {
     "name": "SC Cambuur",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Leeuwarden",
     "stadium": "Cambuur Stadion",
     "stadium_capacity": 10250,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.75
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.06
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "FC Eindhoven",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Eindhoven",
     "stadium": "Jan Louwers Stadion",
     "stadium_capacity": 4600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.9
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 8
     }
   },
   {
     "name": "FC Emmen",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Emmen",
     "stadium": "De Oude Meerdijk",
     "stadium_capacity": 8600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.8
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 33
     }
   },
   {
     "name": "SBV Excelsior",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Rotterdam",
     "stadium": "Van Donge & De Roo Stadion",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.78
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.22
-        }
-      ],
       "mu": 67,
       "sigma": 29
     }
   },
   {
     "name": "FC Den Bosch",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "'s-Hertogenbosch",
     "stadium": "De Vliert",
     "stadium_capacity": 8500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.86
-        },
-        {
-          "name": "China",
-          "probability": 0.07
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.07
-        }
-      ],
       "mu": 66,
       "sigma": 35
     }
   },
   {
     "name": "FC Dordrecht",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Dordrecht",
     "stadium": "GN Bouw Stadion",
     "stadium_capacity": 4234,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.9
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.1
-        }
-      ],
       "mu": 68,
       "sigma": 10
     }
   },
   {
     "name": "HFC Haarlem",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Haarlem",
     "stadium": "Haarlem Stadion",
     "stadium_capacity": 3442,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.79
-        },
-        {
-          "name": "England",
-          "probability": 0.07
-        },
-        {
-          "name": "Italy",
-          "probability": 0.07
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.07
-        }
-      ],
       "mu": 64,
       "sigma": 30
     }
   },
   {
     "name": "Helmond Sport",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Helmond",
     "stadium": "SolarUnie Stadion",
     "stadium_capacity": 4100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.74
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.09
-        },
-        {
-          "name": "Canada",
-          "probability": 0.09
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.09
-        }
-      ],
       "mu": 57,
       "sigma": 27
     }
   },
   {
     "name": "Heracles Almelo",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Almelo",
     "stadium": "Erve Asito",
     "stadium_capacity": 12080,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.85
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.03
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "Canada",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 32
     }
   },
   {
     "name": "MVV Maastricht",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Maastricht",
     "stadium": "De Geusselt",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.74
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.26
-        }
-      ],
       "mu": 54,
       "sigma": 8
     }
   },
   {
     "name": "NAC Breda",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Breda",
     "stadium": "Rat Verlegh Stadion",
     "stadium_capacity": 19000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.84
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        }
-      ],
       "mu": 74,
       "sigma": 30
     }
   },
   {
     "name": "NEC Nijmegen",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Nijmegen",
     "stadium": "Goffertstadion",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.84
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.03
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 10
     }
   },
   {
     "name": "PSV",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Eindhoven",
     "stadium": "Philips Stadion",
     "stadium_capacity": 35119,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.78
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.05
-        },
-        {
-          "name": "Finland",
-          "probability": 0.05
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 20
     }
   },
   {
     "name": "RBC  Roosendaal",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Roosendaal",
     "stadium": "RBC Stadion",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.75
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        },
-        {
-          "name": "Norway",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 10
     }
   },
   {
     "name": "RKC Waalwijk",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Waalwijk",
     "stadium": "Mandemakers Stadion",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.9
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.02
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.02
-        },
-        {
-          "name": "Germany",
-          "probability": 0.02
-        },
-        {
-          "name": "Peru",
-          "probability": 0.02
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.02
-        }
-      ],
       "mu": 52,
       "sigma": 26
     }
   },
   {
     "name": "SC Heerenveen",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Heerenveen",
     "stadium": "Abe Lenstra Stadion",
     "stadium_capacity": 26100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.8
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 24
     }
   },
   {
     "name": "Sparta Rotterdam",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Rotterdam",
     "stadium": "Het Kasteel",
     "stadium_capacity": 11026,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.84
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        },
-        {
-          "name": "Norway",
-          "probability": 0.03
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        }
-      ],
       "mu": 48,
       "sigma": 15
     }
   },
   {
     "name": "TOP Oss",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Oss",
     "stadium": "Frans Heesen Stadion",
     "stadium_capacity": 4700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.78
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 28
     }
   },
   {
     "name": "SC Telstar",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Velsen",
     "stadium": "Tata Steel Stadion",
     "stadium_capacity": 3249,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.73
-        },
-        {
-          "name": "Iran",
-          "probability": 0.27
-        }
-      ],
       "mu": 81,
       "sigma": 32
     }
   },
   {
     "name": "Vitesse",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Arnhem",
     "stadium": "Gelredome",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.77
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.08
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.08
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.08
-        }
-      ],
       "mu": 75,
       "sigma": 24
     }
   },
   {
     "name": "VVV-Venlo",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Venlo",
     "stadium": "De Koel",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.75
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.25
-        }
-      ],
       "mu": 62,
       "sigma": 10
     }
   },
   {
     "name": "SC Veendam",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Veendam",
     "stadium": "De Langeleegte",
     "stadium_capacity": 5290,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Austria",
-          "probability": 0.04
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 21
     }
   },
   {
     "name": "Willem II",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Tilburg",
     "stadium": "Koning Willem II Stadion",
     "stadium_capacity": 14500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.73
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 18
     }
   },
   {
     "name": "De Graafschap",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Doetinchem",
     "stadium": "De Vijverberg",
     "stadium_capacity": 12600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Romania",
-          "probability": 0.09
-        },
-        {
-          "name": "Oman",
-          "probability": 0.09
-        }
-      ],
       "mu": 73,
       "sigma": 35
     }
   },
   {
     "name": "Achilles'29",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Groesbeek",
     "stadium": "Sportpark De Heikant",
     "stadium_capacity": 1999,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.74
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.26
-        }
-      ],
       "mu": 81,
       "sigma": 24
     }
   },
   {
     "name": "Jong Ajax",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Amsterdam",
     "stadium": "De Toekomst",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.84
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.08
-        },
-        {
-          "name": "Australia",
-          "probability": 0.08
-        }
-      ],
       "mu": 61,
       "sigma": 27
     }
   },
   {
     "name": "JVC Cuijk",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Cuijk",
     "stadium": "De Groenendijkse Kampen",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.72
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.09
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.09
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.09
-        }
-      ],
       "mu": 61,
       "sigma": 12
     }
   },
   {
     "name": "VV Capelle",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Capelle aan den IJssel",
     "stadium": "Sportpark 't Slot",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.8
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.05
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 8
     }
   },
   {
     "name": "Excelsior '31",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Rijssen",
     "stadium": "Sportpark De Koerbelt",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.77
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.06
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.06
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.06
-        },
-        {
-          "name": "Laos",
-          "probability": 0.06
-        }
-      ],
       "mu": 60,
       "sigma": 31
     }
   },
   {
     "name": "Haaksbergse SC",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Haaksbergen",
     "stadium": "Scholtenhagen",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.85
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.08
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.08
-        }
-      ],
       "mu": 76,
       "sigma": 16
     }
   },
   {
     "name": "Kozakken Boys",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Werkendam",
     "stadium": "Sportpark De Zwaaier",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.9
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.02
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.02
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.02
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.02
-        }
-      ],
       "mu": 48,
       "sigma": 7
     }
   },
   {
     "name": "DVS'33",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Ermelo",
     "stadium": "Sportpark Zuid DVS '33",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.72
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.28
-        }
-      ],
       "mu": 78,
       "sigma": 10
     }
   },
   {
     "name": "RKAV Volendam",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Volendam",
     "stadium": "KWABO-stadion",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.84
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.03
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        }
-      ],
       "mu": 63,
       "sigma": 11
     }
   },
   {
     "name": "ACV",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Assen",
     "stadium": "Univ\\u00e9 Sportpark",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.09
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.09
-        }
-      ],
       "mu": 72,
       "sigma": 33
     }
   },
   {
     "name": "Jong FC Utrecht",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Utrecht",
     "stadium": "Sportcomplex Zoudenbalch",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.75
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.12
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.12
-        }
-      ],
       "mu": 49,
       "sigma": 6
     }
   },
   {
     "name": "Jong Vitesse",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Arnhem",
     "stadium": "Nationaal Sportcentrum Papendal",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Russia",
-          "probability": 0.06
-        }
-      ],
       "mu": 76,
       "sigma": 32
     }
   },
   {
     "name": "Jong Sparta",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Rotterdam",
     "stadium": "Nieuw Terbregge",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.88
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.03
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 62,
       "sigma": 29
     }
   },
   {
     "name": "DHC Delft",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Delft",
     "stadium": "Sportpark Brasserskade",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.72
-        },
-        {
-          "name": "France",
-          "probability": 0.07
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.07
-        },
-        {
-          "name": "Peru",
-          "probability": 0.07
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        }
-      ],
       "mu": 82,
       "sigma": 18
     }
   },
   {
     "name": "DOVO",
-    "country": "Netherlands",
+    "country": "NED",
     "location": "Veenendaal",
     "stadium": "Sportpark Panhuis",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Netherlands",
-          "probability": 0.82
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.06
-        }
-      ],
       "mu": 61,
       "sigma": 34
     }
   },
   {
     "name": "Hiengh\\u00e8ne Sport",
-    "country": "New Caledonia",
+    "country": "NCL",
     "location": "Hiengh\\u00e8ne",
     "stadium": "Stadium Hien",
     "stadium_capacity": 1800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Caledonia",
-          "probability": 0.89
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.11
-        }
-      ],
       "mu": 77,
       "sigma": 22
     }
   },
   {
     "name": "Auckland City",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Auckland",
     "stadium": "Kiwitea Street",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.78
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.11
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.11
-        }
-      ],
       "mu": 45,
       "sigma": 7
     }
   },
   {
     "name": "Waitakere United",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Waitakere City",
     "stadium": "Fred Taylor Park",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.74
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.13
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.13
-        }
-      ],
       "mu": 79,
       "sigma": 33
     }
   },
   {
     "name": "Team Wellington",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Wellington",
     "stadium": "Newtown Park",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.71
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.29
-        }
-      ],
       "mu": 79,
       "sigma": 17
     }
   },
   {
     "name": "Waikato FC",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Hamilton",
     "stadium": "Porritt Stadium",
     "stadium_capacity": 2700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.76
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.05
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 6
     }
   },
   {
     "name": "Southern United",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Dunedin",
     "stadium": "Forsyth Barr Stadium",
     "stadium_capacity": 30748,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.73
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.07
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.07
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.07
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.07
-        }
-      ],
       "mu": 66,
       "sigma": 33
     }
   },
   {
     "name": "Wairarapa United",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Masterton",
     "stadium": "Howard Booth Park",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.78
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.11
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.11
-        }
-      ],
       "mu": 66,
       "sigma": 12
     }
   },
   {
     "name": "Wellington Olympic",
-    "country": "New Zealand",
+    "country": "NZL",
     "location": "Wellington",
     "stadium": "Wakefield Park",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "New Zealand",
-          "probability": 0.81
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.09
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.09
-        }
-      ],
       "mu": 55,
       "sigma": 25
     }
   },
   {
     "name": "Deportivo Walter Ferretti",
-    "country": "Nicaragua",
+    "country": "NCA",
     "location": "Managua",
     "stadium": "Estadio Olimpico IND",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nicaragua",
-          "probability": 0.88
-        },
-        {
-          "name": "Austria",
-          "probability": 0.12
-        }
-      ],
       "mu": 62,
       "sigma": 19
     }
   },
   {
     "name": "Managua FC",
-    "country": "Nicaragua",
+    "country": "NCA",
     "location": "Managua",
     "stadium": "Estadio Olimpico IND",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nicaragua",
-          "probability": 0.71
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.1
-        },
-        {
-          "name": "France",
-          "probability": 0.1
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.1
-        }
-      ],
       "mu": 84,
       "sigma": 23
     }
   },
   {
     "name": "Deportivo Ocotal",
-    "country": "Nicaragua",
+    "country": "NCA",
     "location": "Ocotal",
     "stadium": "Estadio Glorias del Beisbol Segoviano",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nicaragua",
-          "probability": 0.9
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.02
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.02
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.02
-        },
-        {
-          "name": "Israel",
-          "probability": 0.02
-        }
-      ],
       "mu": 69,
       "sigma": 26
     }
   },
   {
     "name": "Dolphins FC",
-    "country": "Nigeria",
+    "country": "NGA",
     "location": "Port Harcourt",
     "stadium": "Liberation Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nigeria",
-          "probability": 0.83
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.04
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.04
-        }
-      ],
       "mu": 45,
       "sigma": 6
     }
   },
   {
     "name": "Bayelsa United",
-    "country": "Nigeria",
+    "country": "NGA",
     "location": "Yenagoa",
     "stadium": "Sapele Stadium",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nigeria",
-          "probability": 0.83
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 32
     }
   },
   {
     "name": "Niger Tornadoes",
-    "country": "Nigeria",
+    "country": "NGA",
     "location": "Minna",
     "stadium": "Bako Kontagora Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Nigeria",
-          "probability": 0.82
-        },
-        {
-          "name": "Wales",
-          "probability": 0.09
-        },
-        {
-          "name": "Romania",
-          "probability": 0.09
-        }
-      ],
       "mu": 85,
       "sigma": 18
     }
   },
   {
     "name": "FK Milano",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Kumanovo",
     "stadium": "KF Bashkimi Arena",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.78
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 12
     }
   },
   {
     "name": "FK Teteks",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Tetovo",
     "stadium": "Gradski stadion Tetovo",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.88
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 9
     }
   },
   {
     "name": "FK Gorno Lisi\\u010de",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Skopje",
     "stadium": "Boris Trajkovski",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.79
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.21
-        }
-      ],
       "mu": 84,
       "sigma": 19
     }
   },
   {
     "name": "FK Shkupi",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "\\u010cair",
     "stadium": "\\u010cair Stadium",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.76
-        },
-        {
-          "name": "England",
-          "probability": 0.08
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.08
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.08
-        }
-      ],
       "mu": 80,
       "sigma": 29
     }
   },
   {
     "name": "Mladost Carev Dvor",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Carev Dvor",
     "stadium": "Gradski stadion Resen",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.81
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.19
-        }
-      ],
       "mu": 46,
       "sigma": 26
     }
   },
   {
     "name": "Akademija Pandev",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Strumica",
     "stadium": "Stadion Mladost",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.76
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.08
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.08
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.08
-        }
-      ],
       "mu": 77,
       "sigma": 28
     }
   },
   {
     "name": "GFK Tikvesh",
-    "country": "North Macedonia",
+    "country": "MKD",
     "location": "Kavadarci",
     "stadium": "Gradski Stadion",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "North Macedonia",
-          "probability": 0.82
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 6
     }
   },
   {
     "name": "Ballymena United",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Ballymena",
     "stadium": "Ballymena Showgrounds",
     "stadium_capacity": 4390,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.8
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        }
-      ],
       "mu": 80,
       "sigma": 35
     }
   },
   {
     "name": "Ballinamallard United",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Ballinamallard",
     "stadium": "Ferney Park",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.86
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        }
-      ],
       "mu": 69,
       "sigma": 11
     }
   },
   {
     "name": "Dungannon Swifts",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Dungannon",
     "stadium": "Stangmore Park",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.82
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.09
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.09
-        }
-      ],
       "mu": 63,
       "sigma": 8
     }
   },
   {
     "name": "Armagh City",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Armagh",
     "stadium": "Holm Park",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.83
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.04
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 22
     }
   },
   {
     "name": "Queen's University Belfast",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Belfast",
     "stadium": "Upper Malone",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.76
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.05
-        }
-      ],
       "mu": 61,
       "sigma": 11
     }
   },
   {
     "name": "Dergview F.C.",
-    "country": "Northern Ireland",
+    "country": "NIR",
     "location": "Castlederg",
     "stadium": "Darragh Park",
     "stadium_capacity": 1200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Northern Ireland",
-          "probability": 0.89
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.04
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 15
     }
   },
   {
     "name": "Troms\\u00f8 IL",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Troms\\u00f8",
     "stadium": "Alfheim Stadion",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.81
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.19
-        }
-      ],
       "mu": 51,
       "sigma": 34
     }
   },
   {
     "name": "HamKam",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Hamar",
     "stadium": "Briskeby",
     "stadium_capacity": 8068,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.71
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.07
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.07
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.07
-        }
-      ],
       "mu": 57,
       "sigma": 27
     }
   },
   {
     "name": "Kongsvinger IL",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Kongsvinger",
     "stadium": "Gjemselund Stadion",
     "stadium_capacity": 2750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.78
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.22
-        }
-      ],
       "mu": 66,
       "sigma": 7
     }
   },
   {
     "name": "Sandnes Ulf",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Sandnes",
     "stadium": "Sandnes Idrettspark",
     "stadium_capacity": 5550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.75
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.06
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.06
-        }
-      ],
       "mu": 51,
       "sigma": 9
     }
   },
   {
     "name": "Alta IF",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Alta",
     "stadium": "Alta Idrettspark",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.79
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.21
-        }
-      ],
       "mu": 63,
       "sigma": 28
     }
   },
   {
     "name": "Strommen IF",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Str\\u00f8mmen",
     "stadium": "Str\\u00f8mmen Stadion",
     "stadium_capacity": 1800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.9
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.02
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.02
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.02
-        },
-        {
-          "name": "Chile",
-          "probability": 0.02
-        }
-      ],
       "mu": 50,
       "sigma": 18
     }
   },
   {
     "name": "SK Vard Haugesund",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Haugesund",
     "stadium": "Haugesund stadion",
     "stadium_capacity": 8800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.71
-        },
-        {
-          "name": "Romania",
-          "probability": 0.15
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.15
-        }
-      ],
       "mu": 56,
       "sigma": 28
     }
   },
   {
     "name": "Follo FK",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Ski",
     "stadium": "Ski Stadion",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.76
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.24
-        }
-      ],
       "mu": 83,
       "sigma": 32
     }
   },
   {
     "name": "FK Jerv",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Grimstad",
     "stadium": "Levermyr stadion",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.8
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 19
     }
   },
   {
     "name": "Kvik Halden FK",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Halden",
     "stadium": "Halden Stadion",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.79
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.05
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 28
     }
   },
   {
     "name": "Arendal Fotball",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Arendal",
     "stadium": "Bj\\u00f8nnes Stadion",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.73
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.07
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.07
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 25
     }
   },
   {
     "name": "Sola FK",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Sola",
     "stadium": "Sola Stadion",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.81
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        }
-      ],
       "mu": 53,
       "sigma": 34
     }
   },
   {
     "name": "FK Vidar",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Stavanger",
     "stadium": "Lassa Idrettspark",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.82
-        },
-        {
-          "name": "Macao",
-          "probability": 0.18
-        }
-      ],
       "mu": 69,
       "sigma": 31
     }
   },
   {
     "name": "Raufoss IL",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Raufoss",
     "stadium": "NAMMO Stadion",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.79
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.1
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.1
-        }
-      ],
       "mu": 67,
       "sigma": 18
     }
   },
   {
     "name": "Asker Fotball",
-    "country": "Norway",
+    "country": "NOR",
     "location": "Asker",
     "stadium": "F\\u00f8yka Stadion",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Norway",
-          "probability": 0.9
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.1
-        }
-      ],
       "mu": 55,
       "sigma": 5
     }
   },
   {
     "name": "Muscat Club",
-    "country": "Oman",
+    "country": "OMA",
     "location": "Muscat",
     "stadium": "Sultan Qaboos Sports Complex",
     "stadium_capacity": 34000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Oman",
-          "probability": 0.85
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        },
-        {
-          "name": "Australia",
-          "probability": 0.03
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.03
-        }
-      ],
       "mu": 85,
       "sigma": 10
     }
   },
   {
     "name": "Chepo FC",
-    "country": "Panama",
+    "country": "PAN",
     "location": "Chepo",
     "stadium": "Estadio Bernardo Gil",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Panama",
-          "probability": 0.77
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.06
-        }
-      ],
       "mu": 46,
       "sigma": 13
     }
   },
   {
     "name": "Plaza Amador",
-    "country": "Panama",
+    "country": "PAN",
     "location": "Panama City",
     "stadium": "Javier Cruz",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Panama",
-          "probability": 0.8
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Canada",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 16
     }
   },
   {
     "name": "SD Atl\\u00e9tico Nacional",
-    "country": "Panama",
+    "country": "PAN",
     "location": "Ciudad de Panam\\u00e1",
     "stadium": "Javier Cruz",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Panama",
-          "probability": 0.71
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.15
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.15
-        }
-      ],
       "mu": 76,
       "sigma": 30
     }
   },
   {
     "name": "Veraguas Club Deportivo",
-    "country": "Panama",
+    "country": "PAN",
     "location": "Santiago de Veraguas",
     "stadium": "Estadio \\u00c1ristocles Castillo",
     "stadium_capacity": 700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Panama",
-          "probability": 0.75
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.06
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.06
-        }
-      ],
       "mu": 66,
       "sigma": 15
     }
   },
   {
     "name": "Herrera FC",
-    "country": "Panama",
+    "country": "PAN",
     "location": "Herrera",
     "stadium": "Los Milagros",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Panama",
-          "probability": 0.74
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.26
-        }
-      ],
       "mu": 66,
       "sigma": 34
     }
   },
   {
     "name": "2 de Mayo",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Pedro Juan Caballero",
     "stadium": "Estadio Rio Parpiti",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.86
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        }
-      ],
       "mu": 73,
       "sigma": 34
     }
   },
   {
     "name": "Sportivo Trinidense",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Asunci\\u00f3n",
     "stadium": "Mart\\u00edn Torres",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.78
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.05
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.05
-        }
-      ],
       "mu": 76,
       "sigma": 14
     }
   },
   {
     "name": "Sportivo Carapegu\\u00e1",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Carapegu\\u00e1",
     "stadium": "Teniente 1\\u00ba Alcides Gonz\\u00e1lez",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.71
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.29
-        }
-      ],
       "mu": 81,
       "sigma": 20
     }
   },
   {
     "name": "CS San Lorenzo",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "San Lorenzo",
     "stadium": "Estadio Gunther Vogel",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.8
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 28
     }
   },
   {
     "name": "General Caballero JLM",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Doctor Juan Le\\u00f3n Mallorqu\\u00edn",
     "stadium": "Estadio Ka'arendy",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.89
-        },
-        {
-          "name": "United States",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 32
     }
   },
   {
     "name": "Sportivo Ameliano",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Asunci\\u00f3n",
     "stadium": "Estadio Jos\\u00e9 Tom\\u00e1s Silva",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.72
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.28
-        }
-      ],
       "mu": 46,
       "sigma": 23
     }
   },
   {
     "name": "Club General Caballero (JLM)",
-    "country": "Paraguay",
+    "country": "PAR",
     "location": "Doctor Juan Le\\u00f3n Mallorquin",
     "stadium": "Estadio Leandro Ovelar",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Paraguay",
-          "probability": 0.79
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Iran",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        }
-      ],
       "mu": 50,
       "sigma": 14
     }
   },
   {
     "name": "Alianza Atl\\u00e9tico",
-    "country": "Peru",
+    "country": "PER",
     "location": "Sullana",
     "stadium": "Campeones del 36",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.84
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.04
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.04
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.04
-        },
-        {
-          "name": "Oman",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 24
     }
   },
   {
     "name": "Club Cienciano",
-    "country": "Peru",
+    "country": "PER",
     "location": "Cusco",
     "stadium": "Garcilaso de la Vega",
     "stadium_capacity": 42056,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.81
-        },
-        {
-          "name": "China",
-          "probability": 0.05
-        },
-        {
-          "name": "Oman",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 27
     }
   },
   {
     "name": "Coronel Bolognesi",
-    "country": "Peru",
+    "country": "PER",
     "location": "Tacna",
     "stadium": "Jorge Basadre",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.88
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.06
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        }
-      ],
       "mu": 61,
       "sigma": 21
     }
   },
   {
     "name": "FBC Melgar",
-    "country": "Peru",
+    "country": "PER",
     "location": "Arequipa",
     "stadium": "Mariano Melgar",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.85
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.08
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.08
-        }
-      ],
       "mu": 81,
       "sigma": 15
     }
   },
   {
     "name": "Jos\\u00e9 G\\u00e1lvez FBC",
-    "country": "Peru",
+    "country": "PER",
     "location": "Chimbote",
     "stadium": "Manuel Rivera Sanchez",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.77
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 21
     }
   },
   {
     "name": "Sport \\u00c1ncash",
-    "country": "Peru",
+    "country": "PER",
     "location": "Huaraz",
     "stadium": "Rosas Pampa",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.81
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.19
-        }
-      ],
       "mu": 75,
       "sigma": 25
     }
   },
   {
     "name": "Universidad San Martin Porres",
-    "country": "Peru",
+    "country": "PER",
     "location": "Lima",
     "stadium": "Estadio Nacional del Per\\u00fa",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.71
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.06
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.06
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.06
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.06
-        }
-      ],
       "mu": 49,
       "sigma": 32
     }
   },
   {
     "name": "Deportivo Municipal",
-    "country": "Peru",
+    "country": "PER",
     "location": "Lima",
     "stadium": "Estadio Municipal de Chorrillos",
     "stadium_capacity": 13000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.79
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.1
-        },
-        {
-          "name": "Panama",
-          "probability": 0.1
-        }
-      ],
       "mu": 71,
       "sigma": 8
     }
   },
   {
     "name": "San Sim\\u00f3n",
-    "country": "Peru",
+    "country": "PER",
     "location": "Moquegua",
     "stadium": "25 de Noviembre",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.76
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.12
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.12
-        }
-      ],
       "mu": 68,
       "sigma": 7
     }
   },
   {
     "name": "Los Chankas",
-    "country": "Peru",
+    "country": "PER",
     "location": "Andahuaylas",
     "stadium": "Estadio Los Chankas",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.71
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.06
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "India",
-          "probability": 0.06
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        }
-      ],
       "mu": 47,
       "sigma": 21
     }
   },
   {
     "name": "Sport Rosario",
-    "country": "Peru",
+    "country": "PER",
     "location": "Huaraz",
     "stadium": "Rosas Pampa",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.89
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        }
-      ],
       "mu": 63,
       "sigma": 17
     }
   },
   {
     "name": "Deportivo Binacional",
-    "country": "Peru",
+    "country": "PER",
     "location": "Arequipa",
     "stadium": "Estadio Monumental Virgen de Chapi",
     "stadium_capacity": 40370,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Peru",
-          "probability": 0.84
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 14
     }
   },
   {
     "name": "Kaya FC",
-    "country": "Philippines",
+    "country": "PHI",
     "location": "Taguig",
     "stadium": "Emperador Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Philippines",
-          "probability": 0.83
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.17
-        }
-      ],
       "mu": 58,
       "sigma": 11
     }
   },
   {
     "name": "Davao Aguilas",
-    "country": "Philippines",
+    "country": "PHI",
     "location": "Tagum",
     "stadium": "Davao del Norte SC",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Philippines",
-          "probability": 0.73
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.14
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.14
-        }
-      ],
       "mu": 73,
       "sigma": 31
     }
   },
   {
     "name": "Korona Kielce",
-    "country": "Poland",
+    "country": "POL",
     "location": "Kielce",
     "stadium": "Kolporter Arena",
     "stadium_capacity": 15550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.78
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.04
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.04
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.04
-        },
-        {
-          "name": "Iran",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 5
     }
   },
   {
     "name": "Polonia Bytom",
-    "country": "Poland",
+    "country": "POL",
     "location": "Bytom",
     "stadium": "Edwarda Szymkowiaka",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.82
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.18
-        }
-      ],
       "mu": 77,
       "sigma": 14
     }
   },
   {
     "name": "Piast Gliwice",
-    "country": "Poland",
+    "country": "POL",
     "location": "Gliwice",
     "stadium": "Kar-Tel Arena",
     "stadium_capacity": 10037,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.76
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.08
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.08
-        },
-        {
-          "name": "Panama",
-          "probability": 0.08
-        }
-      ],
       "mu": 57,
       "sigma": 16
     }
   },
   {
     "name": "Slask Wroclaw",
-    "country": "Poland",
+    "country": "POL",
     "location": "Wroclaw",
     "stadium": "Stadion Miejski we Wroc\\u0142awiu",
     "stadium_capacity": 43308,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.75
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.08
-        },
-        {
-          "name": "Oman",
-          "probability": 0.08
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.08
-        }
-      ],
       "mu": 84,
       "sigma": 10
     }
   },
   {
     "name": "Flota \\u015awinouj\\u015bcie",
-    "country": "Poland",
+    "country": "POL",
     "location": "\\u015awinouj\\u015bcie",
     "stadium": "Nasz Stadion",
     "stadium_capacity": 3070,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.75
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.06
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.06
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        }
-      ],
       "mu": 68,
       "sigma": 27
     }
   },
   {
     "name": "GKS Katowice",
-    "country": "Poland",
+    "country": "POL",
     "location": "Katowice",
     "stadium": "Bukowa",
     "stadium_capacity": 6170,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.73
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.05
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 27
     }
   },
   {
     "name": "Zawisza Bydgoszcz",
-    "country": "Poland",
+    "country": "POL",
     "location": "Bydgoszcz",
     "stadium": "Zdzis\\u0142aw Krzyszkowiak",
     "stadium_capacity": 20247,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.89
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.11
-        }
-      ],
       "mu": 67,
       "sigma": 6
     }
   },
   {
     "name": "Ruch Radzionk\\u00f3w",
-    "country": "Poland",
+    "country": "POL",
     "location": "Radzionk\\u00f3w",
     "stadium": "Narutowicza",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.74
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.07
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.07
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 20
     }
   },
   {
     "name": "Kolejarz Str\\u00f3\\u017ce",
-    "country": "Poland",
+    "country": "POL",
     "location": "Str\\u00f3\\u017ce",
     "stadium": "Str\\u00f3\\u017ce",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.75
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.05
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.05
-        },
-        {
-          "name": "Peru",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 11
     }
   },
   {
     "name": "Sandecja NS",
-    "country": "Poland",
+    "country": "POL",
     "location": "Nowy Sacz",
     "stadium": "Ojca Wladyslawa",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.8
-        },
-        {
-          "name": "France",
-          "probability": 0.2
-        }
-      ],
       "mu": 58,
       "sigma": 24
     }
   },
   {
     "name": "Mied\\u017a Legnica",
-    "country": "Poland",
+    "country": "POL",
     "location": "Legnica",
     "stadium": "Stadion Miejski w Legnicy",
     "stadium_capacity": 6200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.79
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.1
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.1
-        }
-      ],
       "mu": 78,
       "sigma": 6
     }
   },
   {
     "name": "Stomil Olsztyn",
-    "country": "Poland",
+    "country": "POL",
     "location": "Olsztyn",
     "stadium": "OSiR Stadium",
     "stadium_capacity": 16800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.85
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.08
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.08
-        }
-      ],
       "mu": 59,
       "sigma": 18
     }
   },
   {
     "name": "GKS Tychy",
-    "country": "Poland",
+    "country": "POL",
     "location": "Tychy",
     "stadium": "Tychy City Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.76
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.12
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.12
-        }
-      ],
       "mu": 77,
       "sigma": 14
     }
   },
   {
     "name": "MKS Chojniczanka",
-    "country": "Poland",
+    "country": "POL",
     "location": "Chojnice",
     "stadium": "Miejski Chojniczanka",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.76
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Albania",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        }
-      ],
       "mu": 72,
       "sigma": 12
     }
   },
   {
     "name": "Puszcza Niepolomice",
-    "country": "Poland",
+    "country": "POL",
     "location": "Niepolomice",
     "stadium": "Puszczy",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.89
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.04
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.04
-        }
-      ],
       "mu": 46,
       "sigma": 31
     }
   },
   {
     "name": "Chrobry Glogow",
-    "country": "Poland",
+    "country": "POL",
     "location": "G\\u0142og\\u00f3w",
     "stadium": "Stadion GOS",
     "stadium_capacity": 2895,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.83
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.09
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.09
-        }
-      ],
       "mu": 49,
       "sigma": 20
     }
   },
   {
     "name": "Rozw\\u00f3j Katowice",
-    "country": "Poland",
+    "country": "POL",
     "location": "Katowice",
     "stadium": "Klub Sportowy Rozw\\u00f3j Katowice",
     "stadium_capacity": 2472,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.71
-        },
-        {
-          "name": "Laos",
-          "probability": 0.07
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.07
-        },
-        {
-          "name": "Russia",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 30
     }
   },
   {
     "name": "KS Legionovia",
-    "country": "Poland",
+    "country": "POL",
     "location": "Legionowo",
     "stadium": "Stadion Miejski w Legionowie",
     "stadium_capacity": 1730,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.78
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.22
-        }
-      ],
       "mu": 78,
       "sigma": 14
     }
   },
   {
     "name": "G\\u00f3rnik Walbrzych",
-    "country": "Poland",
+    "country": "POL",
     "location": "Wa\\u0142brzych",
     "stadium": "Stadion 1000-lecia",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.85
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.15
-        }
-      ],
       "mu": 67,
       "sigma": 32
     }
   },
   {
     "name": "Baltyk Gdynia",
-    "country": "Poland",
+    "country": "POL",
     "location": "Gdynia",
     "stadium": "GOSIR",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.84
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.08
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.08
-        }
-      ],
       "mu": 61,
       "sigma": 28
     }
   },
   {
     "name": "Stal Rzesz\\u00f3w",
-    "country": "Poland",
+    "country": "POL",
     "location": "Rzesz\\u00f3w",
     "stadium": "Nasz stadion",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.77
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.08
-        },
-        {
-          "name": "Albania",
-          "probability": 0.08
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.08
-        }
-      ],
       "mu": 62,
       "sigma": 32
     }
   },
   {
     "name": "Znicz Pruszk\\u00f3w",
-    "country": "Poland",
+    "country": "POL",
     "location": "Pruszk\\u00f3w",
     "stadium": "Stadion Znicza Pruszk\\u00f3w",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.84
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.08
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.08
-        }
-      ],
       "mu": 85,
       "sigma": 29
     }
   },
   {
     "name": "OKS Start Otwock",
-    "country": "Poland",
+    "country": "POL",
     "location": "Otwock",
     "stadium": "Stadion Tadeusza \\u015alusarskiego",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.88
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 11
     }
   },
   {
     "name": "Jarota Jarocin",
-    "country": "Poland",
+    "country": "POL",
     "location": "Jarocin",
     "stadium": "Stadion Miejski Jarocin",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.72
-        },
-        {
-          "name": "Greece",
-          "probability": 0.06
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        }
-      ],
       "mu": 70,
       "sigma": 26
     }
   },
   {
     "name": "Stal Mielec",
-    "country": "Poland",
+    "country": "POL",
     "location": "Mielec",
     "stadium": "Stadion Stali Mielec",
     "stadium_capacity": 6864,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.77
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.08
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.08
-        },
-        {
-          "name": "Israel",
-          "probability": 0.08
-        }
-      ],
       "mu": 51,
       "sigma": 33
     }
   },
   {
     "name": "LZS Piotr\\u00f3wka",
-    "country": "Poland",
+    "country": "POL",
     "location": "Piotr\\u00f3wka",
     "stadium": "Stadion Miejski",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.88
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.02
-        },
-        {
-          "name": "Greece",
-          "probability": 0.02
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.02
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.02
-        },
-        {
-          "name": "India",
-          "probability": 0.02
-        }
-      ],
       "mu": 80,
       "sigma": 25
     }
   },
   {
     "name": "KS Polkowice",
-    "country": "Poland",
+    "country": "POL",
     "location": "Polkowice",
     "stadium": "Stadion KS Polkowice",
     "stadium_capacity": 4365,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.83
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 7
     }
   },
   {
     "name": "KS Chwaszczyno",
-    "country": "Poland",
+    "country": "POL",
     "location": "Chwaszczyno",
     "stadium": "Stadion Miejski",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.81
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Japan",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        }
-      ],
       "mu": 69,
       "sigma": 14
     }
   },
   {
     "name": "Elana Toru\\u0144",
-    "country": "Poland",
+    "country": "POL",
     "location": "Toru\\u0144",
     "stadium": "Stadion Grzegorza Duneckiego",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.88
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        },
-        {
-          "name": "Canada",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 18
     }
   },
   {
     "name": "Karpaty Krosno",
-    "country": "Poland",
+    "country": "POL",
     "location": "Krosno",
     "stadium": "Stadion MOSiR",
     "stadium_capacity": 2240,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.83
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.06
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.06
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 30
     }
   },
   {
     "name": "KS Drweca NML",
-    "country": "Poland",
+    "country": "POL",
     "location": "Nowe Miasto Lubawskie",
     "stadium": "Stadion MOSiR",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.77
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.23
-        }
-      ],
       "mu": 70,
       "sigma": 22
     }
   },
   {
     "name": "Stal Brzeg",
-    "country": "Poland",
+    "country": "POL",
     "location": "Brzeg",
     "stadium": "Stadion Miejski w Brzegu",
     "stadium_capacity": 2100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.9
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.03
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        }
-      ],
       "mu": 83,
       "sigma": 16
     }
   },
   {
     "name": "KSZO Ostrowiec \\u015awi\\u0119tokrzyski",
-    "country": "Poland",
+    "country": "POL",
     "location": "Ostrowiec \\u015awi\\u0119tokrzyski",
     "stadium": "Miejski Stadion Sportowy",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.86
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.04
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "Laos",
-          "probability": 0.04
-        }
-      ],
       "mu": 63,
       "sigma": 23
     }
   },
   {
     "name": "GKS Jastrzebie",
-    "country": "Poland",
+    "country": "POL",
     "location": "Jastrz\\u0119bie Zdr\\u00f3j",
     "stadium": "Stadion Miejski",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.85
-        },
-        {
-          "name": "Finland",
-          "probability": 0.03
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 25
     }
   },
   {
     "name": "Podhale Nowy Targ",
-    "country": "Poland",
+    "country": "POL",
     "location": "Nowy Targ",
     "stadium": "Stadion Miejski im. J\\u00f3zefa Pi\\u0142sudskiego",
     "stadium_capacity": 700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.83
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.03
-        }
-      ],
       "mu": 50,
       "sigma": 29
     }
   },
   {
     "name": "Znicz Biala Piska",
-    "country": "Poland",
+    "country": "POL",
     "location": "Bia\\u0142a Piska",
     "stadium": "Edwarda Szymkowiaka",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.82
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Japan",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 19
     }
   },
   {
     "name": "Sleza Wroclaw",
-    "country": "Poland",
+    "country": "POL",
     "location": "Wroc\\u0142aw",
     "stadium": "Intakus Park",
     "stadium_capacity": 2597,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.74
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.26
-        }
-      ],
       "mu": 70,
       "sigma": 16
     }
   },
   {
     "name": "Foto-Higiena Ga\\u0107",
-    "country": "Poland",
+    "country": "POL",
     "location": "Ga\\u0107",
     "stadium": "Stadion w Gaciu",
     "stadium_capacity": 600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.9
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.1
-        }
-      ],
       "mu": 80,
       "sigma": 7
     }
   },
   {
     "name": "G\\u00f3rnik Konin",
-    "country": "Poland",
+    "country": "POL",
     "location": "Konin",
     "stadium": "Stadion Pi\\u0142karski MOSiR",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.87
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.03
-        },
-        {
-          "name": "Albania",
-          "probability": 0.03
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.03
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 16
     }
   },
   {
     "name": "Sok\\u00f3l Ostr\\u00f3da",
-    "country": "Poland",
+    "country": "POL",
     "location": "Ostr\\u00f3da",
     "stadium": "Stadion Miejski w Ostr\\u00f3dzie",
     "stadium_capacity": 4998,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.8
-        },
-        {
-          "name": "Malta",
-          "probability": 0.07
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.07
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.07
-        }
-      ],
       "mu": 68,
       "sigma": 35
     }
   },
   {
     "name": "Zaglebie Lubin II",
-    "country": "Poland",
+    "country": "POL",
     "location": "Lubin",
     "stadium": "Stadion Zag\\u0142\\u0119bia Lubin",
     "stadium_capacity": 16068,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Poland",
-          "probability": 0.73
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.07
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.07
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.07
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 18
     }
   },
   {
     "name": "Acad\\u00e9mica de Coimbra",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Coimbra",
     "stadium": "Est\\u00e1dio Cidade de Coimbra",
     "stadium_capacity": 30154,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.26
-        }
-      ],
       "mu": 82,
       "sigma": 34
     }
   },
   {
     "name": "Alverca",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Alverca do Ribatejo.",
     "stadium": "Complexo Desportivo",
     "stadium_capacity": 6900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.07
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.07
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.07
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.07
-        }
-      ],
       "mu": 46,
       "sigma": 11
     }
   },
   {
     "name": "SC Beira-Mar",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Aveiro",
     "stadium": "Municipal de Aveiro",
     "stadium_capacity": 30498,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.84
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.16
-        }
-      ],
       "mu": 77,
       "sigma": 5
     }
   },
   {
     "name": "B SAD",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lisboa",
     "stadium": "Est\\u00e1dio das Seixas",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.73
-        },
-        {
-          "name": "Oman",
-          "probability": 0.14
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.14
-        }
-      ],
       "mu": 71,
       "sigma": 20
     }
   },
   {
     "name": "SL Benfica",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lisbon",
     "stadium": "Estadio da Luz",
     "stadium_capacity": 65647,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.71
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.29
-        }
-      ],
       "mu": 45,
       "sigma": 24
     }
   },
   {
     "name": "Boavista FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Porto",
     "stadium": "Est\\u00e1dio do Bessa",
     "stadium_capacity": 28263,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.78
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.05
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        }
-      ],
       "mu": 79,
       "sigma": 29
     }
   },
   {
     "name": "Desportivo das Aves",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Vila das Aves",
     "stadium": "Clube Desportivo das Aves",
     "stadium_capacity": 10250,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.03
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.03
-        }
-      ],
       "mu": 61,
       "sigma": 34
     }
   },
   {
     "name": "GD Chaves",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Chaves",
     "stadium": "Municipal Eng. Manuel Branco Teixeira",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.8
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.1
-        },
-        {
-          "name": "Spain",
-          "probability": 0.1
-        }
-      ],
       "mu": 52,
       "sigma": 28
     }
   },
   {
     "name": "GD Estoril Praia",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Estoril",
     "stadium": "Ant\\u00f2nio Coimbra da Mota",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.88
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 22
     }
   },
   {
     "name": "Estrela da Amadora",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Amadora",
     "stadium": "Est\\u00e1dio Jos\\u00e9 Gomes",
     "stadium_capacity": 9288,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.72
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.06
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.06
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 32
     }
   },
   {
     "name": "FC Porto",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Porto",
     "stadium": "Est\\u00e1dio do Drag\\u00e3o",
     "stadium_capacity": 50948,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.85
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.05
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.05
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        }
-      ],
       "mu": 71,
       "sigma": 33
     }
   },
   {
     "name": "CD Feirense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Santa Maria da Feira",
     "stadium": "Marcolino de Castro",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.71
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.06
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Austria",
-          "probability": 0.06
-        }
-      ],
       "mu": 58,
       "sigma": 31
     }
   },
   {
     "name": "FC Felgueiras 1932",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Porto",
     "stadium": "Dr.Machado de Matos",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.07
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.07
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.07
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.07
-        }
-      ],
       "mu": 84,
       "sigma": 5
     }
   },
   {
     "name": "Gil Vicente FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Barcelos",
     "stadium": "Estadio Cidade de Barcelos",
     "stadium_capacity": 12374,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.81
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.06
-        },
-        {
-          "name": "Germany",
-          "probability": 0.06
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.06
-        }
-      ],
       "mu": 82,
       "sigma": 32
     }
   },
   {
     "name": "Gondomar SC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Gondomar",
     "stadium": "Est\\u00e1dio de S\\u00e3o Miguel",
     "stadium_capacity": 2450,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.71
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.1
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.1
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.1
-        }
-      ],
       "mu": 64,
       "sigma": 8
     }
   },
   {
     "name": "Leix\\u00f5es SC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Matosinhos",
     "stadium": "Est\\u00e1dio do Mar",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.81
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.19
-        }
-      ],
       "mu": 66,
       "sigma": 9
     }
   },
   {
     "name": "Maia",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Maia",
     "stadium": "Jos\\u00e9 Vieira",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.81
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.09
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.09
-        }
-      ],
       "mu": 69,
       "sigma": 16
     }
   },
   {
     "name": "Marco",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Marco de Canaveses",
     "stadium": "Est\\u00e1dio Municipal Marco de Canaveses",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.11
-        }
-      ],
       "mu": 54,
       "sigma": 7
     }
   },
   {
     "name": "CS Maritimo",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Funchal",
     "stadium": "Est\\u00e1dio do Mar\\u00edtimo",
     "stadium_capacity": 10932,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.79
-        },
-        {
-          "name": "Peru",
-          "probability": 0.07
-        },
-        {
-          "name": "Wales",
-          "probability": 0.07
-        },
-        {
-          "name": "Iran",
-          "probability": 0.07
-        }
-      ],
       "mu": 77,
       "sigma": 25
     }
   },
   {
     "name": "Moreirense FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Moreira de C\\u00f3negos",
     "stadium": "Comendador Joaquim de Almeida Freitas",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.84
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.08
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.08
-        }
-      ],
       "mu": 46,
       "sigma": 27
     }
   },
   {
     "name": "CD Nacional",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Funchal",
     "stadium": "Est\\u00e1dio da Madeira",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.11
-        }
-      ],
       "mu": 60,
       "sigma": 26
     }
   },
   {
     "name": "Naval 1\\u00ba de Maio",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Figueira da Foz",
     "stadium": "Municipal Jos\\u00e9 Bento Pessoa",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.79
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.21
-        }
-      ],
       "mu": 72,
       "sigma": 30
     }
   },
   {
     "name": "SC Olhanense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Olh\\u00e3o",
     "stadium": "Jos\\u00e9 Arcanjo",
     "stadium_capacity": 5661,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.07
-        },
-        {
-          "name": "Iran",
-          "probability": 0.07
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.07
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.07
-        }
-      ],
       "mu": 64,
       "sigma": 9
     }
   },
   {
     "name": "Ovarense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Ovar",
     "stadium": "Marques da Silva",
     "stadium_capacity": 2284,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.86
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.14
-        }
-      ],
       "mu": 68,
       "sigma": 13
     }
   },
   {
     "name": "Pa\\u00e7os de Ferreira",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Pa\\u00e7os de Ferreira",
     "stadium": "Est\\u00e1dio Capital do M\\u00f3vel",
     "stadium_capacity": 9077,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.84
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        }
-      ],
       "mu": 75,
       "sigma": 27
     }
   },
   {
     "name": "FC Penafiel",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Penafiel",
     "stadium": "25 de Abril",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        }
-      ],
       "mu": 49,
       "sigma": 10
     }
   },
   {
     "name": "Rio Ave",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Vila do Conde",
     "stadium": "Est\\u00e1dio dos Arcos",
     "stadium_capacity": 12820,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.78
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.04
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 32
     }
   },
   {
     "name": "CD Santa Clara",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Ponta Delgada",
     "stadium": "S\\u00e3o Miguel",
     "stadium_capacity": 15277,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.77
-        },
-        {
-          "name": "Angola",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.06
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 20
     }
   },
   {
     "name": "SC Espinho",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Espinho",
     "stadium": "Comendador Manuel Violas",
     "stadium_capacity": 7500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.71
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.15
-        },
-        {
-          "name": "Greece",
-          "probability": 0.15
-        }
-      ],
       "mu": 85,
       "sigma": 35
     }
   },
   {
     "name": "Sporting CP",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lisbon",
     "stadium": "Est\\u00e1dio Jos\\u00e9 Alvalade",
     "stadium_capacity": 50095,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.8
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.07
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.07
-        }
-      ],
       "mu": 46,
       "sigma": 24
     }
   },
   {
     "name": "Uni\\u00e3o de Leiria",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Leiria",
     "stadium": "Est\\u00e1dio Dr. Magalh\\u00e3es Pessoa",
     "stadium_capacity": 29900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.76
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.24
-        }
-      ],
       "mu": 75,
       "sigma": 7
     }
   },
   {
     "name": "UD Oliveirense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Oliveira de Azem\\u00e9is",
     "stadium": "Carlos Os\\u00f3rio",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.76
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.12
-        },
-        {
-          "name": "Russia",
-          "probability": 0.12
-        }
-      ],
       "mu": 58,
       "sigma": 7
     }
   },
   {
     "name": "Atl\\u00e9tico CP",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lisbon",
     "stadium": "Est\\u00e1dio da Tapadinha",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.9
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.02
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.02
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.02
-        },
-        {
-          "name": "Australia",
-          "probability": 0.02
-        },
-        {
-          "name": "Finland",
-          "probability": 0.02
-        }
-      ],
       "mu": 69,
       "sigma": 6
     }
   },
   {
     "name": "CD Tondela",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Tondela",
     "stadium": "Jo\\u00e3o Cardoso",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.83
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 21
     }
   },
   {
     "name": "FC Porto B",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Gaia",
     "stadium": "Dr. Jorge Sampaio",
     "stadium_capacity": 8500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.88
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.12
-        }
-      ],
       "mu": 84,
       "sigma": 31
     }
   },
   {
     "name": "Sporting CP B",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lisbon",
     "stadium": "Est\\u00e1dio Jos\\u00e9 Alvalade",
     "stadium_capacity": 50095,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.03
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        }
-      ],
       "mu": 55,
       "sigma": 9
     }
   },
   {
     "name": "GD Tourizense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Touriz",
     "stadium": "Visconde do Vinhal",
     "stadium_capacity": 1200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.81
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.06
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.06
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.06
-        }
-      ],
       "mu": 64,
       "sigma": 10
     }
   },
   {
     "name": "CD Oper\\u00e1rio",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Lagoa",
     "stadium": "Jo\\u00e3o Gualberto Arruda",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.77
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.23
-        }
-      ],
       "mu": 79,
       "sigma": 8
     }
   },
   {
     "name": "SU Sintrense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Sintra",
     "stadium": "Est\\u00e1dio do Sport Uni\\u00e3o Sintrense",
     "stadium_capacity": 2800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.76
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.08
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.08
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.08
-        }
-      ],
       "mu": 66,
       "sigma": 28
     }
   },
   {
     "name": "CD Cinf\\u00e3es",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Cinf\\u00e3es",
     "stadium": "Est\\u00e1dio Municipal Cerveira Pinto",
     "stadium_capacity": 4690,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "United States",
-          "probability": 0.07
-        },
-        {
-          "name": "China",
-          "probability": 0.07
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.07
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.07
-        }
-      ],
       "mu": 74,
       "sigma": 6
     }
   },
   {
     "name": "SG Sacavenense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Sacav\\u00e9m",
     "stadium": "Est\\u00e1dio do SG Sacavenense",
     "stadium_capacity": 3200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.87
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.07
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.07
-        }
-      ],
       "mu": 75,
       "sigma": 33
     }
   },
   {
     "name": "Fabril do Barreiro",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Barreiro",
     "stadium": "Est\\u00e1dio Alfredo da Silva",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.79
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        }
-      ],
       "mu": 62,
       "sigma": 8
     }
   },
   {
     "name": "AD Sanjoanense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "S\\u00e3o Jo\\u00e3o da Madeira",
     "stadium": "Est\\u00e1dio Conde Dias Garcia",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.79
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.1
-        },
-        {
-          "name": "Albania",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 8
     }
   },
   {
     "name": "SC Praiense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Praia da Vit\\u00f3ria",
     "stadium": "Est\\u00e1dio Municipal da Praia da Vit\\u00f3ria",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.72
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.07
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.07
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.07
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.07
-        }
-      ],
       "mu": 78,
       "sigma": 22
     }
   },
   {
     "name": "Sertanense FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Sert\\u00e3",
     "stadium": "Dr. Marques Santos",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.77
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.06
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.06
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        }
-      ],
       "mu": 71,
       "sigma": 20
     }
   },
   {
     "name": "Santa Maria FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Galegos",
     "stadium": "Est\\u00e1dio da Devesas",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.73
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.27
-        }
-      ],
       "mu": 61,
       "sigma": 7
     }
   },
   {
     "name": "Anadia FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Anadia",
     "stadium": "Est\\u00e1dio Municipal Engenheiro S\\u00edlvio Henriques Cerv",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.9
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        }
-      ],
       "mu": 58,
       "sigma": 19
     }
   },
   {
     "name": "Neves FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Vila de Punhe, Viana do Castelo",
     "stadium": "Est\\u00e1dio Alferes Pinto Ribeiro",
     "stadium_capacity": 2100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.74
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.26
-        }
-      ],
       "mu": 62,
       "sigma": 28
     }
   },
   {
     "name": "\\u00c1guias do Moradal",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Estreito",
     "stadium": "Campo do Ventoso",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.77
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.23
-        }
-      ],
       "mu": 77,
       "sigma": 30
     }
   },
   {
     "name": "Atl\\u00e9tico Malveira",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Malveira",
     "stadium": "Est\\u00e1dio das Seixas",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.85
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 35
     }
   },
   {
     "name": "Alian\\u00e7a de Gandra",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Gandra",
     "stadium": "Campo do Calv\\u00e1rio",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.76
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.08
-        },
-        {
-          "name": "Italy",
-          "probability": 0.08
-        },
-        {
-          "name": "Russia",
-          "probability": 0.08
-        }
-      ],
       "mu": 79,
       "sigma": 35
     }
   },
   {
     "name": "CDC Montalegre",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Montalegre",
     "stadium": "Dr. Diogo Alves Vaz Pereira",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.9
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.1
-        }
-      ],
       "mu": 50,
       "sigma": 18
     }
   },
   {
     "name": "AD Ninense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Vila Nova de Famalic\\u00e3o",
     "stadium": "Complexo Desportivo de Nine",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.9
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 13
     }
   },
   {
     "name": "Ber\\u00e7o SC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Guimar\\u00e3es",
     "stadium": "Campo Jogos D. Maria Teresa",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.86
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.03
-        },
-        {
-          "name": "Australia",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 13
     }
   },
   {
     "name": "Pevid\\u00e9m SC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Guimar\\u00e3es",
     "stadium": "Parque de Jogos Albano Martins Coelho Lima",
     "stadium_capacity": 4555,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.89
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.03
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.03
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        }
-      ],
       "mu": 84,
       "sigma": 29
     }
   },
   {
     "name": "AC Marinhense",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Marinha Grande",
     "stadium": "Est\\u00e1dio Municipal da Marinha Grande",
     "stadium_capacity": 8378,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.82
-        },
-        {
-          "name": "Japan",
-          "probability": 0.18
-        }
-      ],
       "mu": 57,
       "sigma": 7
     }
   },
   {
     "name": "Amora FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Amora",
     "stadium": "Est\\u00e1dio da Medideira",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.79
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.07
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        },
-        {
-          "name": "Romania",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 10
     }
   },
   {
     "name": "Vilanovense FC",
-    "country": "Portugal",
+    "country": "POR",
     "location": "Vila Nova de Gaia",
     "stadium": "Parque Soares dos Reis",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Portugal",
-          "probability": 0.8
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.04
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        }
-      ],
       "mu": 82,
       "sigma": 17
     }
   },
   {
     "name": "Al Sadd SC",
-    "country": "Qatar",
+    "country": "QAT",
     "location": "Doha",
     "stadium": "Jassim Bin Hamad Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Qatar",
-          "probability": 0.71
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.07
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.07
-        },
-        {
-          "name": "Angola",
-          "probability": 0.07
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.07
-        }
-      ],
       "mu": 58,
       "sigma": 19
     }
   },
   {
     "name": "Al Wakrah SC",
-    "country": "Qatar",
+    "country": "QAT",
     "location": "Al Wakrah",
     "stadium": "Al Wakrah Stadium",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Qatar",
-          "probability": 0.77
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.05
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "Finland",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 15
     }
   },
   {
     "name": "Al Khor SC",
-    "country": "Qatar",
+    "country": "QAT",
     "location": "Khor",
     "stadium": "Al-Khawr Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Qatar",
-          "probability": 0.83
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.17
-        }
-      ],
       "mu": 62,
       "sigma": 26
     }
   },
   {
     "name": "Umm Salal",
-    "country": "Qatar",
+    "country": "QAT",
     "location": "Umm Salal",
     "stadium": "Qatar SC Stadium",
     "stadium_capacity": 19000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Qatar",
-          "probability": 0.83
-        },
-        {
-          "name": "Oman",
-          "probability": 0.03
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.03
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.03
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.03
-        }
-      ],
       "mu": 71,
       "sigma": 23
     }
   },
   {
     "name": "El Jaish SC",
-    "country": "Qatar",
+    "country": "QAT",
     "location": "Al Rayyan",
     "stadium": "Ahmed bin Ali",
     "stadium_capacity": 27000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Qatar",
-          "probability": 0.89
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.11
-        }
-      ],
       "mu": 50,
       "sigma": 30
     }
   },
   {
     "name": "Rapid Bucure\\u015fti",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Bucharest",
     "stadium": "Rapid Arena",
     "stadium_capacity": 14050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.81
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.06
-        },
-        {
-          "name": "Italy",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        }
-      ],
       "mu": 64,
       "sigma": 13
     }
   },
   {
     "name": "Unirea Urziceni",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Urziceni",
     "stadium": "Tineretului",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.87
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.13
-        }
-      ],
       "mu": 62,
       "sigma": 22
     }
   },
   {
     "name": "Gloria Buz\\u0103u",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Buz\\u0103u",
     "stadium": "Stadionul Cr\\u00e2ng",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.82
-        },
-        {
-          "name": "Angola",
-          "probability": 0.04
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.04
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.04
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.04
-        }
-      ],
       "mu": 50,
       "sigma": 6
     }
   },
   {
     "name": "CS Otopeni",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Otopeni",
     "stadium": "Otopeni Stadium",
     "stadium_capacity": 1200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.9
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.02
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.02
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.02
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.02
-        }
-      ],
       "mu": 48,
       "sigma": 8
     }
   },
   {
     "name": "FC Boto\\u015fani",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Boto\\u015fani",
     "stadium": "Municipal Boto\\u015fani",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.86
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.07
-        }
-      ],
       "mu": 69,
       "sigma": 25
     }
   },
   {
     "name": "Concordia Chiajna",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Chiajna",
     "stadium": "Concordia",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.87
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        }
-      ],
       "mu": 70,
       "sigma": 20
     }
   },
   {
     "name": "CS Turnu Severin",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Drobeta-Turnu Severin",
     "stadium": "Municipal Drobeta-Turnu Severin",
     "stadium_capacity": 19128,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.89
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.11
-        }
-      ],
       "mu": 78,
       "sigma": 15
     }
   },
   {
     "name": "CSM Re\\u0219i\\u021ba",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Re\\u0219i\\u021ba",
     "stadium": "Stadionul Mircea Chivu",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.9
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.03
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        },
-        {
-          "name": "Oman",
-          "probability": 0.03
-        }
-      ],
       "mu": 48,
       "sigma": 12
     }
   },
   {
     "name": "CS Luceaf\\u0103rul Oradea",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Oradea",
     "stadium": "Luceaf\\u0103rul",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.82
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.09
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.09
-        }
-      ],
       "mu": 59,
       "sigma": 21
     }
   },
   {
     "name": "FC Maramure\\u0219 UBM",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Baia Mare",
     "stadium": "Viorel Mateianu",
     "stadium_capacity": 15524,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.73
-        },
-        {
-          "name": "Finland",
-          "probability": 0.27
-        }
-      ],
       "mu": 54,
       "sigma": 15
     }
   },
   {
     "name": "CS Tunari",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Tunari",
     "stadium": "Tunari",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.72
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.14
-        },
-        {
-          "name": "Austria",
-          "probability": 0.14
-        }
-      ],
       "mu": 79,
       "sigma": 21
     }
   },
   {
     "name": "Ripensia Timisoara",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Timisoara",
     "stadium": "Ciarda Ro\\u0219ie",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.77
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.23
-        }
-      ],
       "mu": 52,
       "sigma": 28
     }
   },
   {
     "name": "Unirea Dej",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Dej",
     "stadium": "Stadionul Municipal Dej",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.87
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.13
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "CA Oradea",
-    "country": "Romania",
+    "country": "ROU",
     "location": "Oradea",
     "stadium": "Iuliu Bodola",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Romania",
-          "probability": 0.72
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.07
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.07
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.07
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 29
     }
   },
   {
     "name": "Lokomotiv Moskva",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Moscow",
     "stadium": "RZD Arena",
     "stadium_capacity": 28800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.71
-        },
-        {
-          "name": "Italy",
-          "probability": 0.1
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.1
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.1
-        }
-      ],
       "mu": 73,
       "sigma": 20
     }
   },
   {
     "name": "FC Rostov",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Rostov-on-Don",
     "stadium": "Rostov Arena",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.85
-        },
-        {
-          "name": "India",
-          "probability": 0.08
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.08
-        }
-      ],
       "mu": 81,
       "sigma": 12
     }
   },
   {
     "name": "SKA Khabarovsk",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Khabarovsk",
     "stadium": "Lenin Stadium",
     "stadium_capacity": 15200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.76
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.12
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.12
-        }
-      ],
       "mu": 76,
       "sigma": 10
     }
   },
   {
     "name": "FC Ufa",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Ufa",
     "stadium": "Neftyanik Stadium",
     "stadium_capacity": 15234,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.79
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 29
     }
   },
   {
     "name": "Metallurg Kuzbass",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Novokuznetsk",
     "stadium": "Metallurg",
     "stadium_capacity": 10500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.78
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.22
-        }
-      ],
       "mu": 49,
       "sigma": 9
     }
   },
   {
     "name": "Dynamo Saint Petersburg",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Saint Petersburg",
     "stadium": "Malaja Sportivnaja Arena",
     "stadium_capacity": 2835,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.74
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.13
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.13
-        }
-      ],
       "mu": 63,
       "sigma": 5
     }
   },
   {
     "name": "Khimik Dzerzhinsk",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Dzerzhinsk",
     "stadium": "Khimik Dzerzhinsk",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.77
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.06
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.06
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        }
-      ],
       "mu": 82,
       "sigma": 23
     }
   },
   {
     "name": "Fakel Voronezh",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Voronezh",
     "stadium": "Tsentralnyi Profsoyuz",
     "stadium_capacity": 32750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.87
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.13
-        }
-      ],
       "mu": 83,
       "sigma": 19
     }
   },
   {
     "name": "Oktan Perm",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Perm",
     "stadium": "Zvezda",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.87
-        },
-        {
-          "name": "Togo",
-          "probability": 0.07
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        }
-      ],
       "mu": 82,
       "sigma": 9
     }
   },
   {
     "name": "Baykal Irkutsk",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Irkutsk",
     "stadium": "Lokomotiv Irkutsk",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.85
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.04
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 19
     }
   },
   {
     "name": "Zenit Penza",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Penza",
     "stadium": "Stadion Pervomayskiy",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.79
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "Finland",
-          "probability": 0.05
-        }
-      ],
       "mu": 54,
       "sigma": 5
     }
   },
   {
     "name": "Metallurg Lipetsk",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Lipetsk",
     "stadium": "Metallurg Stadium",
     "stadium_capacity": 14940,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.86
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.05
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 22
     }
   },
   {
     "name": "Tekstilshchik Ivanovo",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Ivanovo",
     "stadium": "Stadion Tekstilshchik",
     "stadium_capacity": 9565,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.78
-        },
-        {
-          "name": "Poland",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 31
     }
   },
   {
     "name": "Kosmos Dolgoprudnyi",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Dolgoprudny",
     "stadium": "Salyut Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.83
-        },
-        {
-          "name": "Chile",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 8
     }
   },
   {
     "name": "FC Ararat Moskva",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Moscow",
     "stadium": "Stadion Spartak",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.88
-        },
-        {
-          "name": "China",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        }
-      ],
       "mu": 55,
       "sigma": 18
     }
   },
   {
     "name": "FC Pskov-747",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Pskov",
     "stadium": "Lokomotiv Stadium",
     "stadium_capacity": 3010,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.71
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.07
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.07
-        }
-      ],
       "mu": 80,
       "sigma": 28
     }
   },
   {
     "name": "Veles Moskva",
-    "country": "Russia",
+    "country": "RUS",
     "location": "Moscow",
     "stadium": "Spartakovets Stadium",
     "stadium_capacity": 5100,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Russia",
-          "probability": 0.79
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.05
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 17
     }
   },
   {
     "name": "SP Cailungo",
-    "country": "San Marino",
+    "country": "SMR",
     "location": "Cailungo",
     "stadium": "Campo Sportivo di Domagnano",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "San Marino",
-          "probability": 0.79
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.04
-        },
-        {
-          "name": "Norway",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 12
     }
   },
   {
     "name": "Sporting Praia Cruz",
-    "country": "Sao Tome and Principe",
+    "country": "STP",
     "location": "S\\u00e3o Tom\\u00e9",
     "stadium": "Est\\u00e1dio Nacional 12 de Julho",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.76
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.12
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.12
-        }
-      ],
       "mu": 61,
       "sigma": 33
     }
   },
   {
     "name": "Al Shabab",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Riyadh",
     "stadium": "King Fahd International",
     "stadium_capacity": 67000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.78
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.05
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 11
     }
   },
   {
     "name": "Al Ettifaq",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Dammam",
     "stadium": "Prince Mohamed bin Fahd",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.88
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.04
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 5
     }
   },
   {
     "name": "Al Nahda",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Dammam",
     "stadium": "Prince Fahad bin Salman",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.74
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.26
-        }
-      ],
       "mu": 58,
       "sigma": 5
     }
   },
   {
     "name": "Al Mojzel Club",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Al Majma'ah",
     "stadium": "King Salman Sport City Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.76
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.05
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.05
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.05
-        }
-      ],
       "mu": 82,
       "sigma": 23
     }
   },
   {
     "name": "Ohod Club",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Medina",
     "stadium": "Prince Mohammed bin Abdul Aziz Stadium",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.75
-        },
-        {
-          "name": "Romania",
-          "probability": 0.08
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.08
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.08
-        }
-      ],
       "mu": 58,
       "sigma": 10
     }
   },
   {
     "name": "Abha Club",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Abha",
     "stadium": "Prince Mohammed bin Abdul Aziz Stadium",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.89
-        },
-        {
-          "name": "Italy",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 22
     }
   },
   {
     "name": "Al Adalah",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Al-Hulaylah",
     "stadium": "Prince Abdullah bin Jalawi",
     "stadium_capacity": 27550,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.71
-        },
-        {
-          "name": "Poland",
-          "probability": 0.1
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.1
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.1
-        }
-      ],
       "mu": 45,
       "sigma": 11
     }
   },
   {
     "name": "Al Arabi Al Saudi",
-    "country": "Saudi Arabia",
+    "country": "KSA",
     "location": "Unaizah",
     "stadium": "Department of Education Stadium Unaizah",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.77
-        },
-        {
-          "name": "Italy",
-          "probability": 0.23
-        }
-      ],
       "mu": 60,
       "sigma": 16
     }
   },
   {
     "name": "Aberdeen",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Aberdeen",
     "stadium": "Pittodrie",
     "stadium_capacity": 22199,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.8
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.05
-        }
-      ],
       "mu": 74,
       "sigma": 25
     }
   },
   {
     "name": "Brechin City",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Brechin",
     "stadium": "Glebe Park",
     "stadium_capacity": 3960,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.78
-        },
-        {
-          "name": "Poland",
-          "probability": 0.11
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.11
-        }
-      ],
       "mu": 71,
       "sigma": 7
     }
   },
   {
     "name": "Inverurie Loco Works",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Inverurie",
     "stadium": "Harlaw Park",
     "stadium_capacity": 2400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.89
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 31
     }
   },
   {
     "name": "Turriff United",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Turriff",
     "stadium": "The Haughs",
     "stadium_capacity": 2135,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.89
-        },
-        {
-          "name": "England",
-          "probability": 0.02
-        },
-        {
-          "name": "Romania",
-          "probability": 0.02
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.02
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.02
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.02
-        }
-      ],
       "mu": 61,
       "sigma": 30
     }
   },
   {
     "name": "Wick Academy",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Wick",
     "stadium": "Harmsworth Park",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.77
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 31
     }
   },
   {
     "name": "Dalbeattie Star",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Dalbeattie",
     "stadium": "Islecroft Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.75
-        },
-        {
-          "name": "England",
-          "probability": 0.08
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.08
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.08
-        }
-      ],
       "mu": 83,
       "sigma": 11
     }
   },
   {
     "name": "Edinburgh University",
-    "country": "Scotland",
+    "country": "SCO",
     "location": "Edinburgh",
     "stadium": "East Peffermill",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Scotland",
-          "probability": 0.75
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.06
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.06
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.06
-        }
-      ],
       "mu": 46,
       "sigma": 30
     }
   },
   {
     "name": "ASC Niarry Tally",
-    "country": "Senegal",
+    "country": "SEN",
     "location": "Dakar",
     "stadium": "Stade Demba Diop",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Senegal",
-          "probability": 0.83
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.17
-        }
-      ],
       "mu": 49,
       "sigma": 8
     }
   },
   {
     "name": "FK Partizan",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Belgrade",
     "stadium": "Stadion FK Partizan",
     "stadium_capacity": 32710,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.79
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.21
-        }
-      ],
       "mu": 58,
       "sigma": 21
     }
   },
   {
     "name": "FK Smederevo",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Smederevo",
     "stadium": "Stadion FK Smederevo",
     "stadium_capacity": 17200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.74
-        },
-        {
-          "name": "Austria",
-          "probability": 0.13
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.13
-        }
-      ],
       "mu": 69,
       "sigma": 28
     }
   },
   {
     "name": "FK Hajduk 1912",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Kula",
     "stadium": "Hajduk",
     "stadium_capacity": 11710,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.89
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.02
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.02
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.02
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.02
-        },
-        {
-          "name": "Romania",
-          "probability": 0.02
-        }
-      ],
       "mu": 67,
       "sigma": 13
     }
   },
   {
     "name": "FK Vo\\u017edovac",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Belgrade",
     "stadium": "Vo\\u017edovac",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.89
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.02
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.02
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.02
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.02
-        },
-        {
-          "name": "Israel",
-          "probability": 0.02
-        }
-      ],
       "mu": 59,
       "sigma": 5
     }
   },
   {
     "name": "Borac \\u010ca\\u010dak",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "\\u010ca\\u010dak",
     "stadium": "\\u010ca\\u010dak Stadium",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.88
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.02
-        },
-        {
-          "name": "Germany",
-          "probability": 0.02
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.02
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.02
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.02
-        }
-      ],
       "mu": 45,
       "sigma": 28
     }
   },
   {
     "name": "FK Zemun",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Zemun",
     "stadium": "Zemun Stadion",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.74
-        },
-        {
-          "name": "Panama",
-          "probability": 0.09
-        },
-        {
-          "name": "Greece",
-          "probability": 0.09
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.09
-        }
-      ],
       "mu": 57,
       "sigma": 22
     }
   },
   {
     "name": "FK Javor Ivanjica",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Ivanjica",
     "stadium": "Stadion FK Javor",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.84
-        },
-        {
-          "name": "Macao",
-          "probability": 0.03
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.03
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.03
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.03
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 22
     }
   },
   {
     "name": "RFK Novi Sad",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Novi Sad",
     "stadium": "Detelinara",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.71
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.15
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.15
-        }
-      ],
       "mu": 82,
       "sigma": 32
     }
   },
   {
     "name": "FK Teleoptik",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Zemun",
     "stadium": "SC Partizan-Teleoptik",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.71
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.29
-        }
-      ],
       "mu": 71,
       "sigma": 30
     }
   },
   {
     "name": "FK Srem",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Sremska Mitrovica",
     "stadium": "Promenada",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.87
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Laos",
-          "probability": 0.03
-        },
-        {
-          "name": "Togo",
-          "probability": 0.03
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 12
     }
   },
   {
     "name": "OFK Mladenovac",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Mladenovac",
     "stadium": "Selters",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.78
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.22
-        }
-      ],
       "mu": 72,
       "sigma": 34
     }
   },
   {
     "name": "FK Timok Zaje\\u010dar",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Zaje\\u010dar",
     "stadium": "Stadion Kraljevica",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.79
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.21
-        }
-      ],
       "mu": 53,
       "sigma": 29
     }
   },
   {
     "name": "Sloga Petrovac na Mlavi",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Petrovac na Mlavi",
     "stadium": "Stadion FK Sloga",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.83
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.06
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.06
-        }
-      ],
       "mu": 73,
       "sigma": 28
     }
   },
   {
     "name": "FK Sindjeli\\u0107 Beograd",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Belgrade",
     "stadium": "Barutana",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.71
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.07
-        },
-        {
-          "name": "Macao",
-          "probability": 0.07
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.07
-        },
-        {
-          "name": "Italy",
-          "probability": 0.07
-        }
-      ],
       "mu": 84,
       "sigma": 35
     }
   },
   {
     "name": "FK Sindjeli\\u0107 Ni\\u0161",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Ni\\u0161",
     "stadium": "Stadion Ma\\u0161inac",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.8
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.07
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.07
-        }
-      ],
       "mu": 69,
       "sigma": 34
     }
   },
   {
     "name": "FK Kabel",
-    "country": "Serbia",
+    "country": "SRB",
     "location": "Novi Sad",
     "stadium": "Stadion FK Kabel",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Serbia",
-          "probability": 0.8
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.07
-        },
-        {
-          "name": "Israel",
-          "probability": 0.07
-        }
-      ],
       "mu": 52,
       "sigma": 24
     }
   },
   {
     "name": "FC Kallon",
-    "country": "Sierra Leone",
+    "country": "SLE",
     "location": "Freetown",
     "stadium": "National Stadium",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sierra Leone",
-          "probability": 0.75
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.08
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.08
-        },
-        {
-          "name": "Romania",
-          "probability": 0.08
-        }
-      ],
       "mu": 73,
       "sigma": 14
     }
   },
   {
     "name": "Warriors FC",
-    "country": "Singapore",
+    "country": "SGP",
     "location": "Choa Chu Kang",
     "stadium": "Choa Chu Kang Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Singapore",
-          "probability": 0.75
-        },
-        {
-          "name": "Peru",
-          "probability": 0.12
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.12
-        }
-      ],
       "mu": 51,
       "sigma": 16
     }
   },
   {
     "name": "Albirex Niigata Singapore",
-    "country": "Singapore",
+    "country": "SGP",
     "location": "Singapore",
     "stadium": "Jurong East Stadium",
     "stadium_capacity": 2700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Singapore",
-          "probability": 0.76
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Germany",
-          "probability": 0.05
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.05
-        },
-        {
-          "name": "Greece",
-          "probability": 0.05
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.05
-        }
-      ],
       "mu": 60,
       "sigma": 22
     }
   },
   {
     "name": "Tanjong Pagar United",
-    "country": "Singapore",
+    "country": "SGP",
     "location": "Queenstown",
     "stadium": "Queenstown Stadium",
     "stadium_capacity": 3800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Singapore",
-          "probability": 0.88
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 26
     }
   },
   {
     "name": "FC Petr\\u017ealka",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Bratislava",
     "stadium": "za Star\\u00fdm mostom",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.88
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.12
-        }
-      ],
       "mu": 70,
       "sigma": 15
     }
   },
   {
     "name": "MFK Ko\\u0161ice",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Ko\\u0161ice",
     "stadium": "Lokomot\\u00edvy v \\u010cermeli",
     "stadium_capacity": 9600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.85
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.15
-        }
-      ],
       "mu": 75,
       "sigma": 10
     }
   },
   {
     "name": "FC Nitra",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Nitra",
     "stadium": "pod Zoborom",
     "stadium_capacity": 11384,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.74
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.09
-        },
-        {
-          "name": "Togo",
-          "probability": 0.09
-        },
-        {
-          "name": "France",
-          "probability": 0.09
-        }
-      ],
       "mu": 56,
       "sigma": 5
     }
   },
   {
     "name": "MFK Doln\\u00fd Kub\\u00edn",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Doln\\u00fd Kub\\u00edn",
     "stadium": "Stadium Ivan Chod\\u00e1k",
     "stadium_capacity": 1950,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.86
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.14
-        }
-      ],
       "mu": 66,
       "sigma": 16
     }
   },
   {
     "name": "Slavoj Trebisov",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Trebi\\u0161ov",
     "stadium": "\\u0160tadi\\u00f3n Trebi\\u0161ov",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.9
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.02
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.02
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.02
-        },
-        {
-          "name": "Romania",
-          "probability": 0.02
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.02
-        }
-      ],
       "mu": 64,
       "sigma": 28
     }
   },
   {
     "name": "\\u0160K Odeva Lipany",
-    "country": "Slovakia",
+    "country": "SVK",
     "location": "Lipany",
     "stadium": "\\u0160tadi\\u00f3n \\u0160K Odeva",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovakia",
-          "probability": 0.76
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.05
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.05
-        }
-      ],
       "mu": 54,
       "sigma": 30
     }
   },
   {
     "name": "FC Koper",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "Koper",
     "stadium": "Bonifika",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.76
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.12
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.12
-        }
-      ],
       "mu": 50,
       "sigma": 18
     }
   },
   {
     "name": "NK Livar ",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "Ivan\\u010dna Gorica",
     "stadium": "Sportni Park",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.89
-        },
-        {
-          "name": "Peru",
-          "probability": 0.02
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.02
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.02
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.02
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.02
-        }
-      ],
       "mu": 68,
       "sigma": 20
     }
   },
   {
     "name": "NK Mura 05",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "Murska Sobota",
     "stadium": "Fazanerija",
     "stadium_capacity": 3716,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.78
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        },
-        {
-          "name": "Wales",
-          "probability": 0.04
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.04
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        }
-      ],
       "mu": 47,
       "sigma": 19
     }
   },
   {
     "name": "NK Zavr\\u010d",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "Zavr\\u010d",
     "stadium": "\\u0160portni park Zavr\\u010d",
     "stadium_capacity": 300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.78
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.07
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.07
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.07
-        }
-      ],
       "mu": 58,
       "sigma": 6
     }
   },
   {
     "name": "NK Bela Krajina",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "\\u010crnomelj",
     "stadium": "Loka Stadium",
     "stadium_capacity": 1517,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.88
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.02
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.02
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.02
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        }
-      ],
       "mu": 76,
       "sigma": 6
     }
   },
   {
     "name": "NK \\u0160ampion Celje",
-    "country": "Slovenia",
+    "country": "SVN",
     "location": "Celje",
     "stadium": "Arena Z\\'de\\u017eele",
     "stadium_capacity": 13400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Slovenia",
-          "probability": 0.85
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.08
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.08
-        }
-      ],
       "mu": 74,
       "sigma": 13
     }
   },
   {
     "name": "Cape Town Spurs",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Cape Town",
     "stadium": "Cape Town Stadium",
     "stadium_capacity": 55000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.83
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 22
     }
   },
   {
     "name": "Kaizer Chiefs",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Johannesburg",
     "stadium": "Soccer City Stadium",
     "stadium_capacity": 94700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.81
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.06
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.06
-        }
-      ],
       "mu": 67,
       "sigma": 9
     }
   },
   {
     "name": "Orlando Pirates",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Johannesburg",
     "stadium": "Ellis Park",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.81
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.06
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.06
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.06
-        }
-      ],
       "mu": 48,
       "sigma": 10
     }
   },
   {
     "name": "Mamelodi Sundowns",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Pretoria",
     "stadium": "Loftus Stadium",
     "stadium_capacity": 51762,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.89
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.11
-        }
-      ],
       "mu": 76,
       "sigma": 25
     }
   },
   {
     "name": "Swallows FC",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Johannesburg",
     "stadium": "Germiston Stadium",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.87
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.03
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.03
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        }
-      ],
       "mu": 74,
       "sigma": 14
     }
   },
   {
     "name": "Bidvest Wits",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Johannesburg",
     "stadium": "Bidvest Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.88
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 79,
       "sigma": 19
     }
   },
   {
     "name": "Black Leopards",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Thohoyandou",
     "stadium": "Thohoyandou Stadium",
     "stadium_capacity": 40000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.87
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Malta",
-          "probability": 0.03
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 16
     }
   },
   {
     "name": "Bloemfontein Celtic",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Bloemfontein",
     "stadium": "Seisa Ramabodu Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.82
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        },
-        {
-          "name": "Malta",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 7
     }
   },
   {
     "name": "Lamontville Golden Arrows",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Durban",
     "stadium": "King Zwelithini Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.76
-        },
-        {
-          "name": "Oman",
-          "probability": 0.06
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.06
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        }
-      ],
       "mu": 66,
       "sigma": 8
     }
   },
   {
     "name": "Jomo Cosmos",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Johannesburg",
     "stadium": "Huntersfield Stadium",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.88
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.12
-        }
-      ],
       "mu": 48,
       "sigma": 21
     }
   },
   {
     "name": "Maritzburg United",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Pietermaritzburg",
     "stadium": "Harry Gwala Stadium",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.73
-        },
-        {
-          "name": "Finland",
-          "probability": 0.09
-        },
-        {
-          "name": "Romania",
-          "probability": 0.09
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.09
-        }
-      ],
       "mu": 81,
       "sigma": 6
     }
   },
   {
     "name": "Cape Umoya United",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Mafikeng",
     "stadium": "Parow Park",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.83
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.06
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 25
     }
   },
   {
     "name": "Supersport United",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Pretoria",
     "stadium": "Super Stadium",
     "stadium_capacity": 28900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.88
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.04
-        },
-        {
-          "name": "Peru",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 24
     }
   },
   {
     "name": "University of Pretoria",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Pretoria",
     "stadium": "Tuks Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.78
-        },
-        {
-          "name": "Qatar",
-          "probability": 0.11
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.11
-        }
-      ],
       "mu": 46,
       "sigma": 30
     }
   },
   {
     "name": "Baroka FC",
-    "country": "South Africa",
+    "country": "RSA",
     "location": "Ga-Mphahlele",
     "stadium": "Ngwana Mohube Sports Ground",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "South Africa",
-          "probability": 0.88
-        },
-        {
-          "name": "Albania",
-          "probability": 0.12
-        }
-      ],
       "mu": 53,
       "sigma": 8
     }
   },
   {
     "name": "Deportivo Alav\\u00e9s",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Vitoria-Gasteiz",
     "stadium": "Mendizorroza",
     "stadium_capacity": 19900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.75
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.25
-        }
-      ],
       "mu": 75,
       "sigma": 31
     }
   },
   {
     "name": "Albacete Balompi\\u00e9",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Albacete",
     "stadium": "Carlos Belmonte",
     "stadium_capacity": 17300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.86
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.07
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.07
-        }
-      ],
       "mu": 73,
       "sigma": 33
     }
   },
   {
     "name": "UD Almer\\u00eda",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Almer\\u00eda",
     "stadium": "Estadio del Mediterr\\u00e1neo",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Malta",
-          "probability": 0.1
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.1
-        }
-      ],
       "mu": 47,
       "sigma": 16
     }
   },
   {
     "name": "Athletic Club",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Bilbao",
     "stadium": "San Mam\\u00e9s",
     "stadium_capacity": 53332,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.1
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.1
-        }
-      ],
       "mu": 74,
       "sigma": 7
     }
   },
   {
     "name": "Atl\\u00e9tico Madrid",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Madrid",
     "stadium": "Wanda Metropolitano",
     "stadium_capacity": 68000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.89
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.11
-        }
-      ],
       "mu": 72,
       "sigma": 6
     }
   },
   {
     "name": "Barcelona",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Barcelona",
     "stadium": "Camp Nou",
     "stadium_capacity": 99359,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.71
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.06
-        },
-        {
-          "name": "Oman",
-          "probability": 0.06
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.06
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.06
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.06
-        }
-      ],
       "mu": 64,
       "sigma": 30
     }
   },
   {
     "name": "Celta Vigo",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Vigo",
     "stadium": "Bala\\u00eddos",
     "stadium_capacity": 31800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.07
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.07
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.07
-        }
-      ],
       "mu": 56,
       "sigma": 14
     }
   },
   {
     "name": "Granada CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Granada",
     "stadium": "Nuevo Los C\\u00e1rmenes",
     "stadium_capacity": 19336,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "Italy",
-          "probability": 0.04
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.04
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.04
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 18
     }
   },
   {
     "name": "C\\u00e1diz CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "C\\u00e1diz",
     "stadium": "Nuevo Mirandilla",
     "stadium_capacity": 20742,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.86
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 9
     }
   },
   {
     "name": "C\\u00f3rdoba CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "C\\u00f3rdoba",
     "stadium": "Nuevo Arc\\u00e1ngel",
     "stadium_capacity": 21822,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.05
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.05
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.05
-        },
-        {
-          "name": "Australia",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 12
     }
   },
   {
     "name": "RC Deportivo",
-    "country": "Spain",
+    "country": "ESP",
     "location": "A Coru\\u00f1a",
     "stadium": "Riazor",
     "stadium_capacity": 34611,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.76
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.06
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        }
-      ],
       "mu": 78,
       "sigma": 7
     }
   },
   {
     "name": "SD Eibar",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Eibar",
     "stadium": "Ipur\\u00faa Municipal Stadium",
     "stadium_capacity": 8164,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.75
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.06
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.06
-        },
-        {
-          "name": "Russia",
-          "probability": 0.06
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.06
-        }
-      ],
       "mu": 54,
       "sigma": 34
     }
   },
   {
     "name": "Elche CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Elche",
     "stadium": "Mart\\u00ednez Valero",
     "stadium_capacity": 38750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.21
-        }
-      ],
       "mu": 75,
       "sigma": 28
     }
   },
   {
     "name": "RCD Espanyol",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Barcelona",
     "stadium": "RCDE Stadium",
     "stadium_capacity": 40500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.13
-        }
-      ],
       "mu": 75,
       "sigma": 9
     }
   },
   {
     "name": "Getafe CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Madrid",
     "stadium": "Coliseum Alfonso P\\u00e9rez",
     "stadium_capacity": 16300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "United States",
-          "probability": 0.09
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.09
-        }
-      ],
       "mu": 57,
       "sigma": 14
     }
   },
   {
     "name": "Gimn\\u00e0stic Tarragona",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Tarragona",
     "stadium": "Nou Estadi",
     "stadium_capacity": 14500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.04
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Oman",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 13
     }
   },
   {
     "name": "Levante UD",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Valencia",
     "stadium": "Ciutat de Valencia",
     "stadium_capacity": 25354,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.74
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.07
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.07
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.07
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.07
-        }
-      ],
       "mu": 49,
       "sigma": 27
     }
   },
   {
     "name": "Lleida Esportiu",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Lleida",
     "stadium": "Camp d'Esports",
     "stadium_capacity": 13500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.88
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.12
-        }
-      ],
       "mu": 57,
       "sigma": 10
     }
   },
   {
     "name": "RCD Mallorca",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Mallorca",
     "stadium": "Visit Mallorca Estadi",
     "stadium_capacity": 23142,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.83
-        },
-        {
-          "name": "Italy",
-          "probability": 0.17
-        }
-      ],
       "mu": 51,
       "sigma": 31
     }
   },
   {
     "name": "M\\u00e1laga CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "M\\u00e1laga",
     "stadium": "La Rosaleda",
     "stadium_capacity": 30044,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Panama",
-          "probability": 0.1
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.1
-        }
-      ],
       "mu": 52,
       "sigma": 9
     }
   },
   {
     "name": "Atl\\u00e9tico Malague\\u00f1o",
-    "country": "Spain",
+    "country": "ESP",
     "location": "M\\u00e1laga",
     "stadium": "Ciudad Deportiva de la Federaci\\u00f3n Malague\\u00f1a",
     "stadium_capacity": 1300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "Peru",
-          "probability": 0.05
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.05
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 16
     }
   },
   {
     "name": "CD Numancia",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Soria",
     "stadium": "Nuevo Los Pajaritos",
     "stadium_capacity": 10200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.05
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.05
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.05
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.05
-        }
-      ],
       "mu": 61,
       "sigma": 25
     }
   },
   {
     "name": "CA Osasuna",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Pamplona",
     "stadium": "El Sadar",
     "stadium_capacity": 23576,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 9
     }
   },
   {
     "name": "Polideportivo Ejido",
-    "country": "Spain",
+    "country": "ESP",
     "location": "El Ejido",
     "stadium": "Santo Domingo",
     "stadium_capacity": 7870,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.72
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.06
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.06
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.06
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 10
     }
   },
   {
     "name": "Pontevedra CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Pontevedra",
     "stadium": "Pasar\\u00f3n",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 33
     }
   },
   {
     "name": "Racing Ferrol",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Ferrol",
     "stadium": "Estadio de la Malata",
     "stadium_capacity": 12042,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.07
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.07
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.07
-        }
-      ],
       "mu": 81,
       "sigma": 29
     }
   },
   {
     "name": "Real Racing Club",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Santander",
     "stadium": "El Sardinero",
     "stadium_capacity": 22500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.84
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.05
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        }
-      ],
       "mu": 48,
       "sigma": 7
     }
   },
   {
     "name": "Real Betis",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Sevilla",
     "stadium": "Estadio Benito Villamar\\u00edn",
     "stadium_capacity": 60720,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.71
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.06
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.06
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.06
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.06
-        },
-        {
-          "name": "England",
-          "probability": 0.06
-        }
-      ],
       "mu": 76,
       "sigma": 7
     }
   },
   {
     "name": "Real Madrid",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Madrid",
     "stadium": "Santiago Bernab\\u00e9u",
     "stadium_capacity": 85454,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.21
-        }
-      ],
       "mu": 71,
       "sigma": 20
     }
   },
   {
     "name": "Real Murcia",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Murcia",
     "stadium": "Nueva Condomina",
     "stadium_capacity": 33045,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.76
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.12
-        },
-        {
-          "name": "Israel",
-          "probability": 0.12
-        }
-      ],
       "mu": 74,
       "sigma": 29
     }
   },
   {
     "name": "Real Sociedad",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Donostia-San Sebasti\\u00e1n",
     "stadium": "Anoeta",
     "stadium_capacity": 32076,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.74
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.09
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.09
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.09
-        }
-      ],
       "mu": 77,
       "sigma": 6
     }
   },
   {
     "name": "RC Recreativo",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Huelva",
     "stadium": "Nuevo Colombino",
     "stadium_capacity": 21670,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.75
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.12
-        },
-        {
-          "name": "Angola",
-          "probability": 0.12
-        }
-      ],
       "mu": 74,
       "sigma": 6
     }
   },
   {
     "name": "Salamanca CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Salamanca",
     "stadium": "Helm\\u00e1ntico",
     "stadium_capacity": 17341,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.82
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.04
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.04
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.04
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 14
     }
   },
   {
     "name": "Sevilla",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Seville",
     "stadium": "Ram\\u00f3n S\\u00e1nchez Pizju\\u00e1n",
     "stadium_capacity": 45500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.84
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.05
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.05
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 9
     }
   },
   {
     "name": "Real Sporting",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Gij\\u00f3n",
     "stadium": "El Molin\\u00f3n",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.08
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.08
-        }
-      ],
       "mu": 57,
       "sigma": 21
     }
   },
   {
     "name": "CD Tenerife",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Tenerife",
     "stadium": "Heliodoro Rodr\\u00edguez L\\u00f3pez",
     "stadium_capacity": 24000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.9
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.05
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 11
     }
   },
   {
     "name": "Terrassa FC",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Terrassa",
     "stadium": "Ol\\u00edmpic de Terrassa",
     "stadium_capacity": 11500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.15
-        }
-      ],
       "mu": 64,
       "sigma": 24
     }
   },
   {
     "name": "Valencia CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Valencia",
     "stadium": "Mestalla",
     "stadium_capacity": 55000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.06
-        },
-        {
-          "name": "France",
-          "probability": 0.06
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.06
-        }
-      ],
       "mu": 55,
       "sigma": 25
     }
   },
   {
     "name": "Real Valladolid",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Valladolid",
     "stadium": "Nuevo Jos\\u00e9 Zorrilla",
     "stadium_capacity": 26512,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.84
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.08
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.08
-        }
-      ],
       "mu": 82,
       "sigma": 8
     }
   },
   {
     "name": "Villarreal CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Villarreal",
     "stadium": "Estadio de la Cer\\u00e1mica",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.11
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.11
-        }
-      ],
       "mu": 60,
       "sigma": 35
     }
   },
   {
     "name": "Xerez",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Jerez",
     "stadium": "Nuevo Chap\\u00edn",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.89
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.02
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.02
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.02
-        },
-        {
-          "name": "Iran",
-          "probability": 0.02
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.02
-        }
-      ],
       "mu": 56,
       "sigma": 14
     }
   },
   {
     "name": "Real Zaragoza",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Zaragoza",
     "stadium": "La Romareda",
     "stadium_capacity": 34596,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.74
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.13
-        },
-        {
-          "name": "Canada",
-          "probability": 0.13
-        }
-      ],
       "mu": 83,
       "sigma": 25
     }
   },
   {
     "name": "Hercules",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Alicante",
     "stadium": "Jos\\u00e9 Rico P\\u00e9rez",
     "stadium_capacity": 29584,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.04
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.04
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        },
-        {
-          "name": "Israel",
-          "probability": 0.04
-        }
-      ],
       "mu": 53,
       "sigma": 28
     }
   },
   {
     "name": "UD Las Palmas",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Las Palmas de Gran Canaria",
     "stadium": "Gran Canaria",
     "stadium_capacity": 32520,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.71
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.07
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.07
-        },
-        {
-          "name": "Norway",
-          "probability": 0.07
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.07
-        }
-      ],
       "mu": 47,
       "sigma": 24
     }
   },
   {
     "name": "Alicante CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Alicante",
     "stadium": "Jos\\u00e9 Rico P\\u00e9rez",
     "stadium_capacity": 29584,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.07
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.07
-        }
-      ],
       "mu": 48,
       "sigma": 32
     }
   },
   {
     "name": "Barakaldo CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Barakaldo",
     "stadium": "Nuevo Lasesarre",
     "stadium_capacity": 7960,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.74
-        },
-        {
-          "name": "Albania",
-          "probability": 0.09
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.09
-        },
-        {
-          "name": "England",
-          "probability": 0.09
-        }
-      ],
       "mu": 79,
       "sigma": 21
     }
   },
   {
     "name": "Caudal Deportivo",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Mieres",
     "stadium": "Hermanos Antu\\u00f1a",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.82
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.06
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.06
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.06
-        }
-      ],
       "mu": 62,
       "sigma": 10
     }
   },
   {
     "name": "CD Badajoz",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Badajoz",
     "stadium": "Nuevo Vivero",
     "stadium_capacity": 15200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.88
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.12
-        }
-      ],
       "mu": 82,
       "sigma": 34
     }
   },
   {
     "name": "SD Lemona",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Lemoa",
     "stadium": "Arlonagusia",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Canada",
-          "probability": 0.08
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.08
-        }
-      ],
       "mu": 47,
       "sigma": 17
     }
   },
   {
     "name": "UD Logro\\u00f1\\u00e9s",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Logro\\u00f1o",
     "stadium": "Nuevo Las Gaunas",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Russia",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.03
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.03
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.03
-        }
-      ],
       "mu": 81,
       "sigma": 15
     }
   },
   {
     "name": "Atl\\u00e9tico Baleares",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Palma de Mallorca",
     "stadium": "Balear",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.9
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 78,
       "sigma": 33
     }
   },
   {
     "name": "L'Hospitalet",
-    "country": "Spain",
+    "country": "ESP",
     "location": "L'Hospitalet de Llobregat",
     "stadium": "Feixa Llarga",
     "stadium_capacity": 6400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.23
-        }
-      ],
       "mu": 69,
       "sigma": 11
     }
   },
   {
     "name": "Burgos CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Burgos",
     "stadium": "El Plant\\u00edo",
     "stadium_capacity": 12200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.78
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.05
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 34
     }
   },
   {
     "name": "UB Conquense",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Cuenca",
     "stadium": "Nueva Fuensata",
     "stadium_capacity": 6700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.72
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.06
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        }
-      ],
       "mu": 83,
       "sigma": 34
     }
   },
   {
     "name": "Club Marino",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Luanco",
     "stadium": "Miramar",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.09
-        },
-        {
-          "name": "India",
-          "probability": 0.09
-        },
-        {
-          "name": "Albania",
-          "probability": 0.09
-        }
-      ],
       "mu": 62,
       "sigma": 32
     }
   },
   {
     "name": "Gimn\\u00e1stic Torrelavega",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Torrelavega",
     "stadium": "El Malec\\u00f3n",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 13
     }
   },
   {
     "name": "CA Osasuna B",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Pamplona",
     "stadium": "Tajonar",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.06
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.06
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        }
-      ],
       "mu": 68,
       "sigma": 30
     }
   },
   {
     "name": "CD Marino",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Arona",
     "stadium": "Antonio Dom\\u00ednguez Alfonso",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.79
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.07
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.07
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.07
-        }
-      ],
       "mu": 63,
       "sigma": 33
     }
   },
   {
     "name": "CD Tudelano",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Tudela",
     "stadium": "Estadio Ciudad de Tudela",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.9
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.02
-        },
-        {
-          "name": "Laos",
-          "probability": 0.02
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.02
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.02
-        },
-        {
-          "name": "Italy",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 30
     }
   },
   {
     "name": "Real Racing Club B",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Santander",
     "stadium": "La Albericia",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.07
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.07
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.07
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.07
-        }
-      ],
       "mu": 65,
       "sigma": 18
     }
   },
   {
     "name": "SD Logro\\u00f1\\u00e9s",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Logro\\u00f1o",
     "stadium": "Mundial 82",
     "stadium_capacity": 375,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.83
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Iran",
-          "probability": 0.04
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.04
-        }
-      ],
       "mu": 72,
       "sigma": 23
     }
   },
   {
     "name": "CD Izarra",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Estella",
     "stadium": "Merkatondoa",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.07
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        },
-        {
-          "name": "Russia",
-          "probability": 0.07
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.07
-        }
-      ],
       "mu": 45,
       "sigma": 32
     }
   },
   {
     "name": "Pe\\u00f1a Sport",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Tafalla",
     "stadium": "San Francisco",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.27
-        }
-      ],
       "mu": 62,
       "sigma": 32
     }
   },
   {
     "name": "Celta Vigo B",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Vigo",
     "stadium": "Municipal Barreiro",
     "stadium_capacity": 4500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.03
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.03
-        }
-      ],
       "mu": 73,
       "sigma": 6
     }
   },
   {
     "name": "UD Lanzarote",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Arrecife",
     "stadium": "Ciudad Deportiva Lanzarote",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.86
-        },
-        {
-          "name": "Chile",
-          "probability": 0.14
-        }
-      ],
       "mu": 65,
       "sigma": 20
     }
   },
   {
     "name": "CD Dorneda",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Oleiros",
     "stadium": "Eugenio Pardo Conchado",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.83
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.06
-        },
-        {
-          "name": "Poland",
-          "probability": 0.06
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.06
-        }
-      ],
       "mu": 58,
       "sigma": 22
     }
   },
   {
     "name": "Las Palmas Atl\\u00e9tico",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Las Palmas",
     "stadium": "Anexo",
     "stadium_capacity": 500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.9
-        },
-        {
-          "name": "Laos",
-          "probability": 0.02
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.02
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.02
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.02
-        }
-      ],
       "mu": 61,
       "sigma": 6
     }
   },
   {
     "name": "UE Olot",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Olot",
     "stadium": "Municipal d'Olot",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.89
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Nicaragua",
-          "probability": 0.04
-        }
-      ],
       "mu": 56,
       "sigma": 18
     }
   },
   {
     "name": "Real \\u00c1vila CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "\\u00c1vila",
     "stadium": "Adolfo Su\\u00e1rez",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "Laos",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.05
-        }
-      ],
       "mu": 59,
       "sigma": 22
     }
   },
   {
     "name": "Arenas Club",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Getxo",
     "stadium": "Gobela",
     "stadium_capacity": 1200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "India",
-          "probability": 0.06
-        },
-        {
-          "name": "Australia",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        },
-        {
-          "name": "Malta",
-          "probability": 0.06
-        }
-      ],
       "mu": 79,
       "sigma": 7
     }
   },
   {
     "name": "CD Lealtad",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Villaviciosa",
     "stadium": "Estadio Las Callejas",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.71
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.1
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.1
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.1
-        }
-      ],
       "mu": 69,
       "sigma": 16
     }
   },
   {
     "name": "Trival Valderas",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Alcorc\\u00f3n",
     "stadium": "La Canaleja",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Wales",
-          "probability": 0.27
-        }
-      ],
       "mu": 50,
       "sigma": 26
     }
   },
   {
     "name": "Pozuelo de Alarc\\u00f3n",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Pozuelo de Alarc\\u00f3n",
     "stadium": "Valle de las Ca\\u00f1as",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.04
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.04
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.04
-        }
-      ],
       "mu": 48,
       "sigma": 25
     }
   },
   {
     "name": "Jumilla CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Jumilla",
     "stadium": "La Hoya",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.75
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.12
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.12
-        }
-      ],
       "mu": 49,
       "sigma": 18
     }
   },
   {
     "name": "FC Asc\\u00f3",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Asc\\u00f3",
     "stadium": "Estadio Municipal de Asc\\u00f3",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.81
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.09
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.09
-        }
-      ],
       "mu": 53,
       "sigma": 28
     }
   },
   {
     "name": "CD Calahorra",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Calahorra",
     "stadium": "La Planilla",
     "stadium_capacity": 4200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.77
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.08
-        },
-        {
-          "name": "Malta",
-          "probability": 0.08
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.08
-        }
-      ],
       "mu": 70,
       "sigma": 25
     }
   },
   {
     "name": "Uni\\u00f3n Sur Yaiza",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Yaiza",
     "stadium": "Estadio Municipal de Yaiza",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.1
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.1
-        }
-      ],
       "mu": 57,
       "sigma": 10
     }
   },
   {
     "name": "CD Choco",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Redondela",
     "stadium": "Campo Municipal de Santa Mari\\u00f1a",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.73
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.09
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.09
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.09
-        }
-      ],
       "mu": 60,
       "sigma": 25
     }
   },
   {
     "name": "Quintanar del Rey",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Quintanar del Rey",
     "stadium": "San Marcos",
     "stadium_capacity": 2800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.83
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.06
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        }
-      ],
       "mu": 69,
       "sigma": 31
     }
   },
   {
     "name": "CD Boiro",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Boiro",
     "stadium": "Barra\\u00f1a",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.89
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.02
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.02
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.02
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.02
-        },
-        {
-          "name": "Wales",
-          "probability": 0.02
-        }
-      ],
       "mu": 77,
       "sigma": 21
     }
   },
   {
     "name": "UD Mutilvera",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Mutilva",
     "stadium": "Valle Araguren",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.9
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.05
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.05
-        }
-      ],
       "mu": 76,
       "sigma": 20
     }
   },
   {
     "name": "Zamudio SD",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Zamudio",
     "stadium": "Gazituaga",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Oman",
-          "probability": 0.03
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.03
-        },
-        {
-          "name": "Panama",
-          "probability": 0.03
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.03
-        }
-      ],
       "mu": 51,
       "sigma": 19
     }
   },
   {
     "name": "Berganti\\u00f1os FC",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Carballo",
     "stadium": "As Eiroas",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Germany",
-          "probability": 0.04
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.04
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        }
-      ],
       "mu": 69,
       "sigma": 6
     }
   },
   {
     "name": "Internacional de Madrid",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Boadilla del Monte",
     "stadium": "Polideportivo Municipal",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.84
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.16
-        }
-      ],
       "mu": 70,
       "sigma": 6
     }
   },
   {
     "name": "SD Ejea",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Ejea de los Caballeros",
     "stadium": "Estadio Luch\\u00e1n",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Romania",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        }
-      ],
       "mu": 53,
       "sigma": 20
     }
   },
   {
     "name": "UD Ibiza",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Ibiza Town",
     "stadium": "Can Misses",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.76
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Italy",
-          "probability": 0.05
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.05
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.05
-        },
-        {
-          "name": "Albania",
-          "probability": 0.05
-        }
-      ],
       "mu": 75,
       "sigma": 6
     }
   },
   {
     "name": "Silva SD",
-    "country": "Spain",
+    "country": "ESP",
     "location": "A Coru\\u00f1a",
     "stadium": "A Grela",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.85
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        }
-      ],
       "mu": 77,
       "sigma": 14
     }
   },
   {
     "name": "Las Rozas CF",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Las Rozas de Madrid",
     "stadium": "Navalcarb\\u00f3n",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.8
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.05
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.05
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 11
     }
   },
   {
     "name": "Haro Deportivo",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Haro",
     "stadium": "El Mazo",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.87
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.03
-        }
-      ],
       "mu": 70,
       "sigma": 24
     }
   },
   {
     "name": "Deportivo Alav\\u00e9s B",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Vitoria-Gasteiz",
     "stadium": "Jos\\u00e9 Luis Compa\\u00f1\\u00f3n",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.89
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.05
-        }
-      ],
       "mu": 78,
       "sigma": 12
     }
   },
   {
     "name": "UD Tamaraceite",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Las Palmas",
     "stadium": "Campo de F\\u00fatbol Juan Guedes",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.71
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.06
-        },
-        {
-          "name": "Albania",
-          "probability": 0.06
-        },
-        {
-          "name": "Australia",
-          "probability": 0.06
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        },
-        {
-          "name": "Macao",
-          "probability": 0.06
-        }
-      ],
       "mu": 72,
       "sigma": 10
     }
   },
   {
     "name": "EC Granollers",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Granollers",
     "stadium": "Campo Municipal Carrer Girona",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.86
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.07
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.07
-        }
-      ],
       "mu": 54,
       "sigma": 12
     }
   },
   {
     "name": "CD Legan\\u00e9s B",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Madrid",
     "stadium": "Instalaci\\u00f3n Deportiva Butarque",
     "stadium_capacity": 1756,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.84
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.05
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        }
-      ],
       "mu": 84,
       "sigma": 22
     }
   },
   {
     "name": "CD M\\u00f3stoles URJC",
-    "country": "Spain",
+    "country": "ESP",
     "location": "Madrid",
     "stadium": "Estadio El Soto",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Spain",
-          "probability": 0.88
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.04
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.04
-        },
-        {
-          "name": "Macao",
-          "probability": 0.04
-        }
-      ],
       "mu": 60,
       "sigma": 12
     }
   },
   {
     "name": "\\u00d6rgryte IS",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "G\\u00f6teborg",
     "stadium": "Gamla Ullevi",
     "stadium_capacity": 19000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.87
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        }
-      ],
       "mu": 80,
       "sigma": 19
     }
   },
   {
     "name": "J\\u00f6nk\\u00f6pings S\\u00f6dra",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "J\\u00f6nk\\u00f6ping",
     "stadium": "Stadsparksvallen",
     "stadium_capacity": 5200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.75
-        },
-        {
-          "name": "Oman",
-          "probability": 0.06
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.06
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.06
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.06
-        }
-      ],
       "mu": 76,
       "sigma": 22
     }
   },
   {
     "name": "\\u00c4ngelholms FF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "\\u00c4ngelholm",
     "stadium": "\\u00c4nglavallen",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.82
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.18
-        }
-      ],
       "mu": 45,
       "sigma": 6
     }
   },
   {
     "name": "Degerfors IF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Degerfors",
     "stadium": "Stora Valla",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.85
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.04
-        }
-      ],
       "mu": 57,
       "sigma": 28
     }
   },
   {
     "name": "Vasalunds IF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Solna",
     "stadium": "Skytteholms IP",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.85
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.03
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.03
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        }
-      ],
       "mu": 75,
       "sigma": 32
     }
   },
   {
     "name": "Norrby IF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Bor\\u00e5s",
     "stadium": "Bor\\u00e5s Arena",
     "stadium_capacity": 15911,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.87
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "France",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 20
     }
   },
   {
     "name": "Vasteras SK",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "V\\u00e4ster\\u00e5s",
     "stadium": "Swedbank Park",
     "stadium_capacity": 7044,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.75
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.25
-        }
-      ],
       "mu": 79,
       "sigma": 28
     }
   },
   {
     "name": "Huddinge IF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Huddinge",
     "stadium": "K\\u00e4llbrinks IP",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.9
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.03
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.03
-        },
-        {
-          "name": "Croatia",
-          "probability": 0.03
-        }
-      ],
       "mu": 46,
       "sigma": 8
     }
   },
   {
     "name": "Pitea IF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Pite\\u00e5",
     "stadium": "LF Arena",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.72
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.09
-        },
-        {
-          "name": "England",
-          "probability": 0.09
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.09
-        }
-      ],
       "mu": 46,
       "sigma": 10
     }
   },
   {
     "name": "Lunds BK",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Lund",
     "stadium": "Klosterg\\u00e5rdens IP",
     "stadium_capacity": 8560,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.89
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.02
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.02
-        },
-        {
-          "name": "Australia",
-          "probability": 0.02
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.02
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.02
-        }
-      ],
       "mu": 66,
       "sigma": 28
     }
   },
   {
     "name": "Nacka FF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Nacka",
     "stadium": "Boovallen",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.76
-        },
-        {
-          "name": "Australia",
-          "probability": 0.12
-        },
-        {
-          "name": "China",
-          "probability": 0.12
-        }
-      ],
       "mu": 59,
       "sigma": 9
     }
   },
   {
     "name": "Motala AIF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Motala",
     "stadium": "Motala Idrottspark",
     "stadium_capacity": 8500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.72
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.14
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.14
-        }
-      ],
       "mu": 56,
       "sigma": 6
     }
   },
   {
     "name": "Kristianstad FC",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Kristianstad",
     "stadium": "Kristianstads IP",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.75
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.25
-        }
-      ],
       "mu": 49,
       "sigma": 7
     }
   },
   {
     "name": "KSF Prespa Birlik",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Malm\\u00f6",
     "stadium": "Malm\\u00f6 Stadion",
     "stadium_capacity": 27500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.78
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.04
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 8
     }
   },
   {
     "name": "Team ThorenGruppen",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Ume\\u00e5",
     "stadium": "Tegstunets IP",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.74
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.09
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.09
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.09
-        }
-      ],
       "mu": 65,
       "sigma": 30
     }
   },
   {
     "name": "Rynninge IK",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "\\u00d6rebro",
     "stadium": "Grenadj\\u00e4rvallen",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.8
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.1
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.1
-        }
-      ],
       "mu": 65,
       "sigma": 12
     }
   },
   {
     "name": "Lindome GIF",
-    "country": "Sweden",
+    "country": "SWE",
     "location": "Lindome",
     "stadium": "Lindevi IP",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Sweden",
-          "probability": 0.83
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.09
-        },
-        {
-          "name": "United States",
-          "probability": 0.09
-        }
-      ],
       "mu": 64,
       "sigma": 11
     }
   },
   {
     "name": "FC Basel",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Basel",
     "stadium": "St. Jakob-Park",
     "stadium_capacity": 38512,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.83
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.09
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.09
-        }
-      ],
       "mu": 51,
       "sigma": 17
     }
   },
   {
     "name": "FC Z\\u00fcrich",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Z\\u00fcrich",
     "stadium": "Letzigrund",
     "stadium_capacity": 30000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.77
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.08
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.08
-        },
-        {
-          "name": "Canada",
-          "probability": 0.08
-        }
-      ],
       "mu": 50,
       "sigma": 33
     }
   },
   {
     "name": "FC Schaffhausen",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Schaffhausen",
     "stadium": "Breite",
     "stadium_capacity": 7300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.71
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.06
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.06
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.06
-        },
-        {
-          "name": "Togo",
-          "probability": 0.06
-        }
-      ],
       "mu": 70,
       "sigma": 10
     }
   },
   {
     "name": "AC Bellinzona",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Bellinzona",
     "stadium": "Comunale Bellinzona",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.8
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "India",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        }
-      ],
       "mu": 51,
       "sigma": 33
     }
   },
   {
     "name": "FC Wil",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Wil",
     "stadium": "Bergholz",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.88
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.04
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 6
     }
   },
   {
     "name": "FC Lugano",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Lugano",
     "stadium": "Cornaredo",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.76
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.08
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.08
-        },
-        {
-          "name": "Israel",
-          "probability": 0.08
-        }
-      ],
       "mu": 74,
       "sigma": 26
     }
   },
   {
     "name": "FC Locarno",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Locarno",
     "stadium": "del Lido",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.71
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.29
-        }
-      ],
       "mu": 53,
       "sigma": 13
     }
   },
   {
     "name": "Etoile Carouge",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Carouge",
     "stadium": "Fontenette",
     "stadium_capacity": 7200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.89
-        },
-        {
-          "name": "United States",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 24
     }
   },
   {
     "name": "FC K\\u00f6niz",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Liebefeld",
     "stadium": "Liebefeld-Hessgut",
     "stadium_capacity": 2600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.73
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.14
-        },
-        {
-          "name": "Russia",
-          "probability": 0.14
-        }
-      ],
       "mu": 59,
       "sigma": 17
     }
   },
   {
     "name": "FC Le Mont",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Le Mont-sur-Lausanne",
     "stadium": "Terrain du Ch\\u00e2taignier",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.9
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.1
-        }
-      ],
       "mu": 84,
       "sigma": 22
     }
   },
   {
     "name": "FC Breitenrain Bern",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Bern",
     "stadium": "Spitalacker",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.71
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.06
-        },
-        {
-          "name": "Tunisia",
-          "probability": 0.06
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.06
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.06
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        }
-      ],
       "mu": 75,
       "sigma": 9
     }
   },
   {
     "name": "Rapperswil-Jona",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Rapperswil",
     "stadium": "Stadion Gr\\u00fcnfeld",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.82
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.06
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 17
     }
   },
   {
     "name": "FC Sion II",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Sion",
     "stadium": "Tourbillon",
     "stadium_capacity": 19600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.85
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.08
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.08
-        }
-      ],
       "mu": 63,
       "sigma": 12
     }
   },
   {
     "name": "FC St. Gallen II",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "St. Gallen",
     "stadium": "Stadion Espenmoos",
     "stadium_capacity": 5700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.73
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.07
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.07
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.07
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 28
     }
   },
   {
     "name": "FC Baden",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Baden",
     "stadium": "Esp Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.84
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.04
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.04
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        }
-      ],
       "mu": 64,
       "sigma": 5
     }
   },
   {
     "name": "FC M\\u00fcnsingen",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "M\\u00fcnsingen",
     "stadium": "Sportanlage Sandreutenen",
     "stadium_capacity": 1400,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.79
-        },
-        {
-          "name": "Spain",
-          "probability": 0.04
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.04
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.04
-        },
-        {
-          "name": "China",
-          "probability": 0.04
-        },
-        {
-          "name": "Ghana",
-          "probability": 0.04
-        }
-      ],
       "mu": 58,
       "sigma": 10
     }
   },
   {
     "name": "Stade Lausanne-Ouchy",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Lausanne",
     "stadium": "Stade Juan-Antonio Samaranch",
     "stadium_capacity": 3200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.76
-        },
-        {
-          "name": "Poland",
-          "probability": 0.06
-        },
-        {
-          "name": "Japan",
-          "probability": 0.06
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.06
-        }
-      ],
       "mu": 81,
       "sigma": 6
     }
   },
   {
     "name": "FC Bavois",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Bavois",
     "stadium": "Stade des Peupliers",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.77
-        },
-        {
-          "name": "India",
-          "probability": 0.05
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Romania",
-          "probability": 0.05
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.05
-        }
-      ],
       "mu": 69,
       "sigma": 21
     }
   },
   {
     "name": "La Chaux-de-Fonds",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "La Chaux-de-Fonds",
     "stadium": "Centre Sportif de la Charri\\u00e8re",
     "stadium_capacity": 10200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.73
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.07
-        },
-        {
-          "name": "Malta",
-          "probability": 0.07
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.07
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.07
-        }
-      ],
       "mu": 57,
       "sigma": 32
     }
   },
   {
     "name": "FC Muri",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Muri",
     "stadium": "Stadion Br\\u00fchl",
     "stadium_capacity": 2350,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.84
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.05
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        }
-      ],
       "mu": 49,
       "sigma": 28
     }
   },
   {
     "name": "Zug 94",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Zug",
     "stadium": "Herti Allmend Stadion",
     "stadium_capacity": 4900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.82
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.05
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.05
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.05
-        },
-        {
-          "name": "Peru",
-          "probability": 0.05
-        }
-      ],
       "mu": 83,
       "sigma": 17
     }
   },
   {
     "name": "Yverdon Sport",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Yverdon-les-Bains",
     "stadium": "Stade Municipal Yverdon",
     "stadium_capacity": 6600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.78
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        },
-        {
-          "name": "Russia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.04
-        }
-      ],
       "mu": 68,
       "sigma": 20
     }
   },
   {
     "name": "FC Fribourg",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Fribourg",
     "stadium": "Stade Universitaire Saint-L\\u00e9onard",
     "stadium_capacity": 9000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.72
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.09
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.09
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.09
-        }
-      ],
       "mu": 74,
       "sigma": 31
     }
   },
   {
     "name": "Red Star Z\\u00fcrich",
-    "country": "Switzerland",
+    "country": "SUI",
     "location": "Z\\u00fcrich",
     "stadium": "Sportanlage Allmend Brunau",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Switzerland",
-          "probability": 0.77
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.11
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.11
-        }
-      ],
       "mu": 48,
       "sigma": 22
     }
   },
   {
     "name": "Simba SC",
-    "country": "Tanzania",
+    "country": "TAN",
     "location": "Dar es Salaam",
     "stadium": "Benjamin Mkapa National Stadium",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tanzania",
-          "probability": 0.82
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.06
-        },
-        {
-          "name": "Italy",
-          "probability": 0.06
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        }
-      ],
       "mu": 48,
       "sigma": 18
     }
   },
   {
     "name": "Azam FC",
-    "country": "Tanzania",
+    "country": "TAN",
     "location": "Dar es Salaam",
     "stadium": "Chamazi Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tanzania",
-          "probability": 0.78
-        },
-        {
-          "name": "Greece",
-          "probability": 0.22
-        }
-      ],
       "mu": 59,
       "sigma": 10
     }
   },
   {
     "name": "Singida United",
-    "country": "Tanzania",
+    "country": "TAN",
     "location": "Singida",
     "stadium": "Namfua Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tanzania",
-          "probability": 0.81
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.09
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.09
-        }
-      ],
       "mu": 70,
       "sigma": 14
     }
   },
   {
     "name": "Police Tero FC",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Bangkok",
     "stadium": "72nd Anniversary Stadium",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.71
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.29
-        }
-      ],
       "mu": 57,
       "sigma": 10
     }
   },
   {
     "name": "Chonburi",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Chonburi",
     "stadium": "Chonburi Stadium",
     "stadium_capacity": 8500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.87
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.03
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.03
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        }
-      ],
       "mu": 58,
       "sigma": 11
     }
   },
   {
     "name": "Songkhla United",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Songkhla",
     "stadium": "Tinsulanon Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.86
-        },
-        {
-          "name": "Togo",
-          "probability": 0.04
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.04
-        }
-      ],
       "mu": 73,
       "sigma": 24
     }
   },
   {
     "name": "Chainat FC",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Chainat",
     "stadium": "Chainat Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.75
-        },
-        {
-          "name": "Panama",
-          "probability": 0.12
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.12
-        }
-      ],
       "mu": 47,
       "sigma": 15
     }
   },
   {
     "name": "Air Force Central",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Rangsit",
     "stadium": "Thupatemee Stadium",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.71
-        },
-        {
-          "name": "Wales",
-          "probability": 0.06
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.06
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.06
-        },
-        {
-          "name": "Russia",
-          "probability": 0.06
-        },
-        {
-          "name": "China",
-          "probability": 0.06
-        }
-      ],
       "mu": 83,
       "sigma": 31
     }
   },
   {
     "name": "Nakhon Ratchasima",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Nakhon Ratchasima",
     "stadium": "80th Birthday Stadium",
     "stadium_capacity": 20141,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.83
-        },
-        {
-          "name": "Albania",
-          "probability": 0.04
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.04
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.04
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.04
-        }
-      ],
       "mu": 52,
       "sigma": 19
     }
   },
   {
     "name": "Prachuap FC",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Prachuap Khiri Khan",
     "stadium": "Sam Ao Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.86
-        },
-        {
-          "name": "Malta",
-          "probability": 0.14
-        }
-      ],
       "mu": 49,
       "sigma": 13
     }
   },
   {
     "name": "Sukhothai FC",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Sukhothai",
     "stadium": "Thung Thalay Luang Stadium",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.73
-        },
-        {
-          "name": "Laos",
-          "probability": 0.09
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.09
-        },
-        {
-          "name": "Norway",
-          "probability": 0.09
-        }
-      ],
       "mu": 67,
       "sigma": 29
     }
   },
   {
     "name": "Khon Kaen United",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Khon Kaen",
     "stadium": "Khon Kaen Stadium",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.87
-        },
-        {
-          "name": "England",
-          "probability": 0.04
-        },
-        {
-          "name": "Spain",
-          "probability": 0.04
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.04
-        }
-      ],
       "mu": 62,
       "sigma": 16
     }
   },
   {
     "name": "Trat FC",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Trat",
     "stadium": "Trat Province Stadium",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.8
-        },
-        {
-          "name": "Germany",
-          "probability": 0.2
-        }
-      ],
       "mu": 61,
       "sigma": 22
     }
   },
   {
     "name": "Ayutthaya United",
-    "country": "Thailand",
+    "country": "THA",
     "location": "Sena",
     "stadium": "Ayutthaya Province Stadium",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Thailand",
-          "probability": 0.74
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.07
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.07
-        },
-        {
-          "name": "Poland",
-          "probability": 0.07
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.07
-        }
-      ],
       "mu": 51,
       "sigma": 15
     }
   },
   {
     "name": "Marantha FC",
-    "country": "Togo",
+    "country": "TOG",
     "location": "Fiokpo",
     "stadium": "Stade Municipal Wom\\u00e9",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Togo",
-          "probability": 0.88
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.06
-        }
-      ],
       "mu": 72,
       "sigma": 5
     }
   },
   {
     "name": "Defence Force",
-    "country": "Trinidad & Tobago",
+    "country": "TRI",
     "location": "Chaguaramas",
     "stadium": "Hasely Crawford Stadium",
     "stadium_capacity": 27000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.84
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.03
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.03
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.03
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        }
-      ],
       "mu": 84,
       "sigma": 9
     }
   },
   {
     "name": "CS Sfaxien",
-    "country": "Tunisia",
+    "country": "TUN",
     "location": "Sfax",
     "stadium": "Ta\\u00efeb-Mhiri",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tunisia",
-          "probability": 0.74
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.09
-        },
-        {
-          "name": "Jordan",
-          "probability": 0.09
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.09
-        }
-      ],
       "mu": 52,
       "sigma": 21
     }
   },
   {
     "name": "JS Kairouan",
-    "country": "Tunisia",
+    "country": "TUN",
     "location": "Kairouan",
     "stadium": "Stade Ali Zouaoui",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tunisia",
-          "probability": 0.79
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.1
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.1
-        }
-      ],
       "mu": 73,
       "sigma": 9
     }
   },
   {
     "name": "EGS Gafsa",
-    "country": "Tunisia",
+    "country": "TUN",
     "location": "Gafsa",
     "stadium": "Stade du 7 Novembre de Gafsa",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Tunisia",
-          "probability": 0.84
-        },
-        {
-          "name": "Scotland",
-          "probability": 0.03
-        },
-        {
-          "name": "Kazakhstan",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.03
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.03
-        }
-      ],
       "mu": 62,
       "sigma": 30
     }
   },
   {
     "name": "Fenerbah\\u00e7e SK",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "\\u0130stanbul",
     "stadium": "\\u015e\\u00fckr\\u00fc Saraco\\u011flu Stadium",
     "stadium_capacity": 50530,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.89
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.05
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 5
     }
   },
   {
     "name": "Manisaspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Manisa",
     "stadium": "Manisa 19 Mayis Stadi",
     "stadium_capacity": 17000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "England",
-          "probability": 0.19
-        }
-      ],
       "mu": 53,
       "sigma": 29
     }
   },
   {
     "name": "Gaziantepspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Gaziantep",
     "stadium": "Gaziantep Arena",
     "stadium_capacity": 33502,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "Poland",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.06
-        },
-        {
-          "name": "United States",
-          "probability": 0.06
-        }
-      ],
       "mu": 57,
       "sigma": 34
     }
   },
   {
     "name": "Kayseri Erciyesspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Kayseri",
     "stadium": "Atat\\u00fcrk Kayseri",
     "stadium_capacity": 33000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.77
-        },
-        {
-          "name": "Panama",
-          "probability": 0.08
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.08
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.08
-        }
-      ],
       "mu": 59,
       "sigma": 31
     }
   },
   {
     "name": "Konyaspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Konya",
     "stadium": "Konya B\\u00fcy\\u00fck\\u015fehir",
     "stadium_capacity": 42000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.05
-        },
-        {
-          "name": "Angola",
-          "probability": 0.05
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.05
-        }
-      ],
       "mu": 62,
       "sigma": 15
     }
   },
   {
     "name": "Kocaelispor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Izmit",
     "stadium": "Ismet Pasa Stadium",
     "stadium_capacity": 16800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.84
-        },
-        {
-          "name": "Paraguay",
-          "probability": 0.04
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.04
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.04
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 33
     }
   },
   {
     "name": "Kasimpa\\u015fa SK",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "\\u0130stanbul",
     "stadium": "Recep Tayyip Erdo\\u011fan",
     "stadium_capacity": 13500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.84
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.04
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        }
-      ],
       "mu": 65,
       "sigma": 15
     }
   },
   {
     "name": "Boluspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Bolu",
     "stadium": "Bolu Atat\\u00fcrk",
     "stadium_capacity": 8881,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.89
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.02
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.02
-        },
-        {
-          "name": "Uzbekistan",
-          "probability": 0.02
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.02
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.02
-        }
-      ],
       "mu": 70,
       "sigma": 11
     }
   },
   {
     "name": "Giresunspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Giresun",
     "stadium": "\\u00c7otanak Stadyumu",
     "stadium_capacity": 22028,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.78
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.11
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.11
-        }
-      ],
       "mu": 74,
       "sigma": 24
     }
   },
   {
     "name": "1461 Trabzon",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Trabzon",
     "stadium": "Ahmet Suat \\u00d6zyaz\\u0131c\\u0131",
     "stadium_capacity": 7700,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.88
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.04
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.04
-        }
-      ],
       "mu": 54,
       "sigma": 15
     }
   },
   {
     "name": "Adana Demirspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Adana",
     "stadium": "New Adana Stadium",
     "stadium_capacity": 36117,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.88
-        },
-        {
-          "name": "Norway",
-          "probability": 0.03
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Equatorial Guinea",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 30
     }
   },
   {
     "name": "Ey\\u00fcpspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Istanbul",
     "stadium": "Ey\\u00fcp Stadium",
     "stadium_capacity": 2500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.8
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.04
-        },
-        {
-          "name": "Angola",
-          "probability": 0.04
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.04
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        }
-      ],
       "mu": 55,
       "sigma": 8
     }
   },
   {
     "name": "Bal\\u0131kesirspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Bal\\u0131kesir",
     "stadium": "Bal\\u0131kesir Atat\\u00fcrk Stadium",
     "stadium_capacity": 15800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.77
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.23
-        }
-      ],
       "mu": 51,
       "sigma": 20
     }
   },
   {
     "name": "\\u00c7anakkale Dardanelspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "\\u00c7anakkale",
     "stadium": "18 Mart Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.88
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 20
     }
   },
   {
     "name": "\\u0130neg\\u00f6lspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "\\u0130neg\\u00f6l",
     "stadium": "\\u0130neg\\u00f6l \\u0130l\\u00e7e Stadyumu",
     "stadium_capacity": 10500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.89
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.03
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.03
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.03
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.03
-        }
-      ],
       "mu": 45,
       "sigma": 20
     }
   },
   {
     "name": "Aydinspor 1923",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Ayd\\u0131n",
     "stadium": "Adnan Menderes",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.9
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.1
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "Kirklarelispor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "K\\u0131rklareli",
     "stadium": "K\\u0131rklareli Atat\\u00fcrk Stadium",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.89
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.03
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.03
-        }
-      ],
       "mu": 60,
       "sigma": 27
     }
   },
   {
     "name": "1922 Konyaspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Konya",
     "stadium": "12 \\u015eubat Stadium",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.8
-        },
-        {
-          "name": "Peru",
-          "probability": 0.07
-        },
-        {
-          "name": "Belgium",
-          "probability": 0.07
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.07
-        }
-      ],
       "mu": 48,
       "sigma": 25
     }
   },
   {
     "name": "Fatih Karag\\u00fcmr\\u00fck",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Istanbul",
     "stadium": "Atat\\u00fcrk Olimpiyat Stadyumu",
     "stadium_capacity": 76092,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.71
-        },
-        {
-          "name": "Germany",
-          "probability": 0.07
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.07
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.07
-        },
-        {
-          "name": "Korea Republic",
-          "probability": 0.07
-        }
-      ],
       "mu": 47,
       "sigma": 17
     }
   },
   {
     "name": "Anadolu \\u00dcsk\\u00fcdar",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Istanbul",
     "stadium": "Vefa Stadium",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.71
-        },
-        {
-          "name": "Kosovo",
-          "probability": 0.1
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.1
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.1
-        }
-      ],
       "mu": 74,
       "sigma": 5
     }
   },
   {
     "name": "Amed SK",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Diyarbak\\u0131r",
     "stadium": "Seyrantepe",
     "stadium_capacity": 1540,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.82
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.06
-        },
-        {
-          "name": "North Macedonia",
-          "probability": 0.06
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.06
-        }
-      ],
       "mu": 74,
       "sigma": 31
     }
   },
   {
     "name": "Sivas Belediye Spor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Sivas",
     "stadium": "Muhsin Yaz\\u0131c\\u0131o\\u011flu Stadium",
     "stadium_capacity": 2150,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.19
-        }
-      ],
       "mu": 84,
       "sigma": 22
     }
   },
   {
     "name": "Sancaktepe Belediyespor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Sancaktepe",
     "stadium": "Hakan \\u015e\\u00fck\\u00fcr Stadyumu",
     "stadium_capacity": 7000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.88
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.12
-        }
-      ],
       "mu": 63,
       "sigma": 11
     }
   },
   {
     "name": "Kilimli Belediyespor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Zonguldak",
     "stadium": "Ahmet \\u015eerifo\\u011flu Stad\\u0131",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.78
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.05
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.05
-        },
-        {
-          "name": "Chile",
-          "probability": 0.05
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.05
-        }
-      ],
       "mu": 72,
       "sigma": 10
     }
   },
   {
     "name": "Beylerbeyispor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Istanbul",
     "stadium": "Beylerbeyi 75. Y\\u0131l Stad\\u0131",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.9
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.02
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.02
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.02
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.02
-        }
-      ],
       "mu": 59,
       "sigma": 10
     }
   },
   {
     "name": "Artvin Hopaspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Hopa",
     "stadium": "Hopa \\u015eehir Stad\\u0131",
     "stadium_capacity": 3200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.88
-        },
-        {
-          "name": "United States",
-          "probability": 0.04
-        },
-        {
-          "name": "Poland",
-          "probability": 0.04
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.04
-        }
-      ],
       "mu": 59,
       "sigma": 5
     }
   },
   {
     "name": "Sultanbeyli Belediyespor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Istanbul",
     "stadium": "Sultanbeyli Belediye Stad\\u0131",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.05
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        }
-      ],
       "mu": 56,
       "sigma": 22
     }
   },
   {
     "name": "G\\u00f6lc\\u00fckspor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "G\\u00f6lc\\u00fck",
     "stadium": "G\\u00f6lc\\u00fck \\u015eehir Stadyumu",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.81
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Portugal",
-          "probability": 0.06
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.06
-        }
-      ],
       "mu": 48,
       "sigma": 34
     }
   },
   {
     "name": "Karak\\u00f6pr\\u00fc Belediyespor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Karak\\u00f6pr\\u00fc",
     "stadium": "Faruk \\u00c7elik Spor Kompleksi",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.72
-        },
-        {
-          "name": "Albania",
-          "probability": 0.07
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.07
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.07
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.07
-        }
-      ],
       "mu": 62,
       "sigma": 28
     }
   },
   {
     "name": "Bayburt \\u00d6zelidarespor",
-    "country": "Turkey",
+    "country": "TUR",
     "location": "Bayburt",
     "stadium": "Gen\\u00e7 Osman Stadyumu",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Turkey",
-          "probability": 0.82
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Wales",
-          "probability": 0.05
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.05
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.05
-        }
-      ],
       "mu": 55,
       "sigma": 20
     }
   },
   {
     "name": "Dynamo Kyiv",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Kiev",
     "stadium": "Olimpiysky NSC",
     "stadium_capacity": 70050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.73
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.05
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.05
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.05
-        },
-        {
-          "name": "Saudi Arabia",
-          "probability": 0.05
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.05
-        }
-      ],
       "mu": 70,
       "sigma": 29
     }
   },
   {
     "name": "Shakhtar Donetsk",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Donetsk",
     "stadium": "Olimpiysky NSC",
     "stadium_capacity": 70050,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.72
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.09
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.09
-        },
-        {
-          "name": "Austria",
-          "probability": 0.09
-        }
-      ],
       "mu": 75,
       "sigma": 22
     }
   },
   {
     "name": "Dnipro Dnipropetrovsk",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Dnipropetrovsk",
     "stadium": "Dnipro Arena",
     "stadium_capacity": 31003,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.87
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.03
-        },
-        {
-          "name": "Belarus",
-          "probability": 0.03
-        },
-        {
-          "name": "Austria",
-          "probability": 0.03
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 22
     }
   },
   {
     "name": "FC Metalist 1925 Kharkiv",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Kharkiv",
     "stadium": "Metalist Stadium",
     "stadium_capacity": 40003,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.88
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.12
-        }
-      ],
       "mu": 81,
       "sigma": 13
     }
   },
   {
     "name": "Metalurh Donetsk",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Donetsk",
     "stadium": "Shakhtar",
     "stadium_capacity": 31718,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.77
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.08
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.08
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.08
-        }
-      ],
       "mu": 73,
       "sigma": 29
     }
   },
   {
     "name": "Desna Chernihiv",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Chernihiv",
     "stadium": "Chernihiv Stadium",
     "stadium_capacity": 12060,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.85
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.05
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 15
     }
   },
   {
     "name": "Stal Kamianske",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Kamianske",
     "stadium": "Metalurh Dniprodzerzhynsk",
     "stadium_capacity": 2900,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.9
-        },
-        {
-          "name": "Armenia",
-          "probability": 0.02
-        },
-        {
-          "name": "Spain",
-          "probability": 0.02
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.02
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.02
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.02
-        }
-      ],
       "mu": 60,
       "sigma": 12
     }
   },
   {
     "name": "Kremin Kremenchuk",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Kremenchuk",
     "stadium": "Kremin Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.76
-        },
-        {
-          "name": "Macao",
-          "probability": 0.12
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.12
-        }
-      ],
       "mu": 59,
       "sigma": 29
     }
   },
   {
     "name": "FC Cherkashchyna",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Cherkasy",
     "stadium": "Tsentralnyi Stadion Cherkasy",
     "stadium_capacity": 10321,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.83
-        },
-        {
-          "name": "Germany",
-          "probability": 0.03
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.03
-        },
-        {
-          "name": "New Zealand",
-          "probability": 0.03
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.03
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.03
-        }
-      ],
       "mu": 56,
       "sigma": 30
     }
   },
   {
     "name": "Inhulets Petrove",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Petrove",
     "stadium": "Inhulets Stadium",
     "stadium_capacity": 1720,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.77
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.23
-        }
-      ],
       "mu": 83,
       "sigma": 25
     }
   },
   {
     "name": "Skala Stryi",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Stryi",
     "stadium": "Sokil Stadium",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.71
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.1
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.1
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.1
-        }
-      ],
       "mu": 45,
       "sigma": 20
     }
   },
   {
     "name": "Polissya Zhytomyr",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Zhytomyr",
     "stadium": "Tsentralnyi Stadion Zhytomyr",
     "stadium_capacity": 21928,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.84
-        },
-        {
-          "name": "United States",
-          "probability": 0.03
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.03
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.03
-        },
-        {
-          "name": "Iraq",
-          "probability": 0.03
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 15
     }
   },
   {
     "name": "Sudnobudivnyk Mykolaiv",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Mykolaiv",
     "stadium": "Tsentralnyi Mykolaiv",
     "stadium_capacity": 25175,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.81
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.19
-        }
-      ],
       "mu": 68,
       "sigma": 19
     }
   },
   {
     "name": "Podillya Khmelnytskyi",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Khmelnytskyi",
     "stadium": "Podillya",
     "stadium_capacity": 6800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.72
-        },
-        {
-          "name": "China",
-          "probability": 0.14
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.14
-        }
-      ],
       "mu": 63,
       "sigma": 29
     }
   },
   {
     "name": "FSC Mariupol",
-    "country": "Ukraine",
+    "country": "UKR",
     "location": "Mariupol",
     "stadium": "Azovets Stadium",
     "stadium_capacity": 1660,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Ukraine",
-          "probability": 0.81
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.04
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.04
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.04
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.04
-        }
-      ],
       "mu": 74,
       "sigma": 31
     }
   },
   {
     "name": "Emirates Club",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Ras al-Khaimah",
     "stadium": "Emirates Club Stadium",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.71
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.07
-        },
-        {
-          "name": "Ukraine",
-          "probability": 0.07
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.07
-        },
-        {
-          "name": "Macao",
-          "probability": 0.07
-        }
-      ],
       "mu": 60,
       "sigma": 22
     }
   },
   {
     "name": "Al Jazira",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Abu Dhabi",
     "stadium": "Al Jazira Mohammed Bin Zayed Stadium",
     "stadium_capacity": 42056,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.9
-        },
-        {
-          "name": "Poland",
-          "probability": 0.03
-        },
-        {
-          "name": "United States",
-          "probability": 0.03
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 20
     }
   },
   {
     "name": "Al Wasl",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Dubai",
     "stadium": "Zabeel Stadium",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.78
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.22
-        }
-      ],
       "mu": 69,
       "sigma": 34
     }
   },
   {
     "name": "Al Sharjah",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Sharjah",
     "stadium": "Sharjah Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.85
-        },
-        {
-          "name": "England",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.03
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.03
-        },
-        {
-          "name": "Spain",
-          "probability": 0.03
-        }
-      ],
       "mu": 46,
       "sigma": 14
     }
   },
   {
     "name": "Baniyas SC",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Abu Dhabi",
     "stadium": "Baniyas",
     "stadium_capacity": 22000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.77
-        },
-        {
-          "name": "Brazil",
-          "probability": 0.06
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.06
-        },
-        {
-          "name": "Togo",
-          "probability": 0.06
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.06
-        }
-      ],
       "mu": 75,
       "sigma": 9
     }
   },
   {
     "name": "Ittihad Kalba",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Kalba",
     "stadium": "Kalba",
     "stadium_capacity": 3000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.75
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.12
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.12
-        }
-      ],
       "mu": 68,
       "sigma": 35
     }
   },
   {
     "name": "Dibba Al Fujairah",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Fujairah",
     "stadium": "Fujairah Club Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.9
-        },
-        {
-          "name": "Guatemala",
-          "probability": 0.02
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.02
-        },
-        {
-          "name": "Hong Kong",
-          "probability": 0.02
-        },
-        {
-          "name": "Poland",
-          "probability": 0.02
-        }
-      ],
       "mu": 54,
       "sigma": 30
     }
   },
   {
     "name": "Al Fujairah SC",
-    "country": "United Arab Emirates",
+    "country": "UAE",
     "location": "Fujairah",
     "stadium": "Fujairah Club Stadium",
     "stadium_capacity": 1500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.74
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.13
-        },
-        {
-          "name": "Bolivia",
-          "probability": 0.13
-        }
-      ],
       "mu": 49,
       "sigma": 14
     }
   },
   {
     "name": "D.C. United",
-    "country": "United States",
+    "country": "USA",
     "location": "Washington D.C.",
     "stadium": "Audi Field",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.84
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        },
-        {
-          "name": "Israel",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        }
-      ],
       "mu": 85,
       "sigma": 32
     }
   },
   {
     "name": "Colorado Rapids",
-    "country": "United States",
+    "country": "USA",
     "location": "Colorado",
     "stadium": "DSG Park",
     "stadium_capacity": 19680,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.76
-        },
-        {
-          "name": "Kyrgyzstan",
-          "probability": 0.24
-        }
-      ],
       "mu": 61,
       "sigma": 27
     }
   },
   {
     "name": "Columbus Crew",
-    "country": "United States",
+    "country": "USA",
     "location": "Columbus, OH",
     "stadium": "Lower.com Field",
     "stadium_capacity": 20011,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.88
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.02
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.02
-        },
-        {
-          "name": "Sao Tome and Principe",
-          "probability": 0.02
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.02
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.02
-        }
-      ],
       "mu": 63,
       "sigma": 12
     }
   },
   {
     "name": "FC Dallas",
-    "country": "United States",
+    "country": "USA",
     "location": "Frisco",
     "stadium": "Toyota Stadium",
     "stadium_capacity": 20500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.8
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.1
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.1
-        }
-      ],
       "mu": 85,
       "sigma": 25
     }
   },
   {
     "name": "Los Angeles Galaxy",
-    "country": "United States",
+    "country": "USA",
     "location": "Los Angeles",
     "stadium": "Dignity Health Sports Park",
     "stadium_capacity": 27000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.86
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.03
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.03
-        },
-        {
-          "name": "Azerbaijan",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        }
-      ],
       "mu": 80,
       "sigma": 25
     }
   },
   {
     "name": "New England Revolution",
-    "country": "United States",
+    "country": "USA",
     "location": "Foxborough",
     "stadium": "Gillette Stadium",
     "stadium_capacity": 22385,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.71
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.29
-        }
-      ],
       "mu": 49,
       "sigma": 25
     }
   },
   {
     "name": "Tampa Bay Rowdies",
-    "country": "United States",
+    "country": "USA",
     "location": "Tampa",
     "stadium": "Al Lang Stadium",
     "stadium_capacity": 7227,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.88
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.12
-        }
-      ],
       "mu": 62,
       "sigma": 15
     }
   },
   {
     "name": "Richmond Kickers",
-    "country": "United States",
+    "country": "USA",
     "location": "Richmond",
     "stadium": "City Stadium",
     "stadium_capacity": 22600,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.89
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.04
-        },
-        {
-          "name": "Chile",
-          "probability": 0.04
-        },
-        {
-          "name": "Canada",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 29
     }
   },
   {
     "name": "Fort Lauderdale CF",
-    "country": "United States",
+    "country": "USA",
     "location": "Miami",
     "stadium": "DRV PNK Stadium",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.76
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.24
-        }
-      ],
       "mu": 65,
       "sigma": 6
     }
   },
   {
     "name": "Penn FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Harrisburg",
     "stadium": "FNB Field",
     "stadium_capacity": 6187,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.8
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.1
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.1
-        }
-      ],
       "mu": 79,
       "sigma": 13
     }
   },
   {
     "name": "Charleston Battery",
-    "country": "United States",
+    "country": "USA",
     "location": "Charleston",
     "stadium": "Blackbaud Stadium",
     "stadium_capacity": 5113,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.8
-        },
-        {
-          "name": "Cameroon",
-          "probability": 0.05
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.05
-        },
-        {
-          "name": "Morocco",
-          "probability": 0.05
-        },
-        {
-          "name": "Russia",
-          "probability": 0.05
-        }
-      ],
       "mu": 45,
       "sigma": 20
     }
   },
   {
     "name": "OKC Energy FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Oklahoma City",
     "stadium": "Pribil Stadium",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.83
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.03
-        },
-        {
-          "name": "Maldives",
-          "probability": 0.03
-        },
-        {
-          "name": "India",
-          "probability": 0.03
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        },
-        {
-          "name": "Peru",
-          "probability": 0.03
-        }
-      ],
       "mu": 76,
       "sigma": 6
     }
   },
   {
     "name": "Sacramento Republic FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Sacramento",
     "stadium": "Charles C. Hughes Stadium",
     "stadium_capacity": 20311,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.84
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        },
-        {
-          "name": "Latvia",
-          "probability": 0.05
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 19
     }
   },
   {
     "name": "Austin Aztex",
-    "country": "United States",
+    "country": "USA",
     "location": "Austin",
     "stadium": "House Park",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.89
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.03
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.03
-        },
-        {
-          "name": "Malaysia",
-          "probability": 0.03
-        }
-      ],
       "mu": 66,
       "sigma": 30
     }
   },
   {
     "name": "Charlotte Independence",
-    "country": "United States",
+    "country": "USA",
     "location": "Charlotte",
     "stadium": "American Legion Memorial Stadium",
     "stadium_capacity": 21000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.78
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.04
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.04
-        },
-        {
-          "name": "Japan",
-          "probability": 0.04
-        }
-      ],
       "mu": 66,
       "sigma": 7
     }
   },
   {
     "name": "Colorado Springs Switchbacks",
-    "country": "United States",
+    "country": "USA",
     "location": "Colorado Springs",
     "stadium": "Sand Creek Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.87
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.04
-        },
-        {
-          "name": "Italy",
-          "probability": 0.04
-        },
-        {
-          "name": "Guyana",
-          "probability": 0.04
-        }
-      ],
       "mu": 79,
       "sigma": 25
     }
   },
   {
     "name": "Tacoma Defiance",
-    "country": "United States",
+    "country": "USA",
     "location": "Seattle",
     "stadium": "Cheney Stadium",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.87
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.04
-        },
-        {
-          "name": "Angola",
-          "probability": 0.04
-        },
-        {
-          "name": "Norway",
-          "probability": 0.04
-        }
-      ],
       "mu": 73,
       "sigma": 16
     }
   },
   {
     "name": "New York RB 2",
-    "country": "United States",
+    "country": "USA",
     "location": "New York",
     "stadium": "Columbia Soccer Stadium",
     "stadium_capacity": 3500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.83
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.06
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.06
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        }
-      ],
       "mu": 53,
       "sigma": 8
     }
   },
   {
     "name": "Atlanta United",
-    "country": "United States",
+    "country": "USA",
     "location": "Atlanta",
     "stadium": "Mercedes-Benz Stadium",
     "stadium_capacity": 71000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.71
-        },
-        {
-          "name": "Venezuela",
-          "probability": 0.15
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.15
-        }
-      ],
       "mu": 50,
       "sigma": 34
     }
   },
   {
     "name": "Philadelphia Union-2",
-    "country": "United States",
+    "country": "USA",
     "location": "Bethlehem",
     "stadium": "Goodman Stadium",
     "stadium_capacity": 16000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.71
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.06
-        },
-        {
-          "name": "Italy",
-          "probability": 0.06
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.06
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.06
-        },
-        {
-          "name": "Malta",
-          "probability": 0.06
-        }
-      ],
       "mu": 85,
       "sigma": 9
     }
   },
   {
     "name": "Atlanta United 2",
-    "country": "United States",
+    "country": "USA",
     "location": "Lawrenceville",
     "stadium": "Coolray Field",
     "stadium_capacity": 10427,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.88
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.02
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.02
-        },
-        {
-          "name": "Togo",
-          "probability": 0.02
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.02
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.02
-        }
-      ],
       "mu": 83,
       "sigma": 7
     }
   },
   {
     "name": "Austin FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Austin",
     "stadium": "Q2 stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.78
-        },
-        {
-          "name": "Slovenia",
-          "probability": 0.22
-        }
-      ],
       "mu": 55,
       "sigma": 23
     }
   },
   {
     "name": "Chattanooga Red Wolves",
-    "country": "United States",
+    "country": "USA",
     "location": "Chattanooga",
     "stadium": "David Stanton Field",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.74
-        },
-        {
-          "name": "Zimbabwe",
-          "probability": 0.07
-        },
-        {
-          "name": "Uruguay",
-          "probability": 0.07
-        },
-        {
-          "name": "Moldova",
-          "probability": 0.07
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.07
-        }
-      ],
       "mu": 85,
       "sigma": 28
     }
   },
   {
     "name": "Loudoun United",
-    "country": "United States",
+    "country": "USA",
     "location": "Leesburg",
     "stadium": "Loudoun United Stadium",
     "stadium_capacity": 5000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.78
-        },
-        {
-          "name": "Kuwait",
-          "probability": 0.11
-        },
-        {
-          "name": "Indonesia",
-          "probability": 0.11
-        }
-      ],
       "mu": 75,
       "sigma": 17
     }
   },
   {
     "name": "Oakland Roots",
-    "country": "United States",
+    "country": "USA",
     "location": "Oakland",
     "stadium": "Laney College",
     "stadium_capacity": 5500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.73
-        },
-        {
-          "name": "Lithuania",
-          "probability": 0.09
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.09
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.09
-        }
-      ],
       "mu": 63,
       "sigma": 19
     }
   },
   {
     "name": "Charlotte FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Charlotte",
     "stadium": "Bank of America Stadium",
     "stadium_capacity": 75325,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.75
-        },
-        {
-          "name": "India",
-          "probability": 0.12
-        },
-        {
-          "name": "Senegal",
-          "probability": 0.12
-        }
-      ],
       "mu": 78,
       "sigma": 16
     }
   },
   {
     "name": "St. Louis City SC",
-    "country": "United States",
+    "country": "USA",
     "location": "St. Louis",
     "stadium": "St. Louis City Stadium",
     "stadium_capacity": 22500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.88
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Vietnam",
-          "probability": 0.03
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        }
-      ],
       "mu": 59,
       "sigma": 6
     }
   },
   {
     "name": "Corpus Christi FC",
-    "country": "United States",
+    "country": "USA",
     "location": "Corpus Christi",
     "stadium": "Jack Dugan Family Soccer and Track Stadium",
     "stadium_capacity": 750,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "United States",
-          "probability": 0.84
-        },
-        {
-          "name": "Angola",
-          "probability": 0.05
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.05
-        },
-        {
-          "name": "Panama",
-          "probability": 0.05
-        }
-      ],
       "mu": 58,
       "sigma": 14
     }
   },
   {
     "name": "Liverpool FC Montevideo",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo",
     "stadium": "Belvedere",
     "stadium_capacity": 9500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.86
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.05
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.05
-        },
-        {
-          "name": "Trinidad & Tobago",
-          "probability": 0.05
-        }
-      ],
       "mu": 69,
       "sigma": 20
     }
   },
   {
     "name": "River Plate de Montevideo",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo",
     "stadium": "Saroldi",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.76
-        },
-        {
-          "name": "Ecuador",
-          "probability": 0.24
-        }
-      ],
       "mu": 56,
       "sigma": 16
     }
   },
   {
     "name": "Miramar Misiones",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo",
     "stadium": "M\\u00e9ndez Piana",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.83
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.17
-        }
-      ],
       "mu": 47,
       "sigma": 7
     }
   },
   {
     "name": "CA Atenas",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "San Carlos",
     "stadium": "Atenas San Carlos",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.88
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.02
-        },
-        {
-          "name": "Jamaica",
-          "probability": 0.02
-        },
-        {
-          "name": "Bulgaria",
-          "probability": 0.02
-        },
-        {
-          "name": "South Africa",
-          "probability": 0.02
-        },
-        {
-          "name": "Italy",
-          "probability": 0.02
-        }
-      ],
       "mu": 58,
       "sigma": 5
     }
   },
   {
     "name": "Canadian SC",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo",
     "stadium": "Obdulio Jacinto Varela",
     "stadium_capacity": 6500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.79
-        },
-        {
-          "name": "Macao",
-          "probability": 0.1
-        },
-        {
-          "name": "Iran",
-          "probability": 0.1
-        }
-      ],
       "mu": 62,
       "sigma": 20
     }
   },
   {
     "name": "Ferro Carril Salto",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Salto",
     "stadium": "Luis Tom\\u00e1s Merazzi",
     "stadium_capacity": 1000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.76
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.08
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.08
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.08
-        }
-      ],
       "mu": 45,
       "sigma": 9
     }
   },
   {
     "name": "Uruguay Montevideo",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo, Uruguay",
     "stadium": "Parque Salus",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.76
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.24
-        }
-      ],
       "mu": 60,
       "sigma": 28
     }
   },
   {
     "name": "La Luz FC",
-    "country": "Uruguay",
+    "country": "URU",
     "location": "Montevideo",
     "stadium": "Parque Luis Rivero",
     "stadium_capacity": 4000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uruguay",
-          "probability": 0.77
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.05
-        },
-        {
-          "name": "Finland",
-          "probability": 0.05
-        },
-        {
-          "name": "Singapore",
-          "probability": 0.05
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.05
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.05
-        }
-      ],
       "mu": 66,
       "sigma": 6
     }
   },
   {
     "name": "FK Bukhara",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Boukhara",
     "stadium": "Pakhtakor Markaziy Stadium",
     "stadium_capacity": 35000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.89
-        },
-        {
-          "name": "Australia",
-          "probability": 0.04
-        },
-        {
-          "name": "Egypt",
-          "probability": 0.04
-        },
-        {
-          "name": "Northern Ireland",
-          "probability": 0.04
-        }
-      ],
       "mu": 78,
       "sigma": 33
     }
   },
   {
     "name": "PFK Andijan",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Andijan",
     "stadium": "Soghlom Avlod Stadium",
     "stadium_capacity": 18360,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.86
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.03
-        },
-        {
-          "name": "Iran",
-          "probability": 0.03
-        },
-        {
-          "name": "Cyprus",
-          "probability": 0.03
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.03
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.03
-        }
-      ],
       "mu": 46,
       "sigma": 13
     }
   },
   {
     "name": "FK Mash'al Mubarek",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Mubarek",
     "stadium": "Bahrom Vafoev Stadium",
     "stadium_capacity": 11000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.89
-        },
-        {
-          "name": "Ivory Coast",
-          "probability": 0.05
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.05
-        }
-      ],
       "mu": 51,
       "sigma": 17
     }
   },
   {
     "name": "Metallurg Bekabad",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Bekabad",
     "stadium": "Metallurg Bekabad Stadium",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.83
-        },
-        {
-          "name": "Mongolia",
-          "probability": 0.09
-        },
-        {
-          "name": "Canada",
-          "probability": 0.09
-        }
-      ],
       "mu": 66,
       "sigma": 32
     }
   },
   {
     "name": "Qizilqum Zarafshon",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Zarafshan",
     "stadium": "Yoshlar Stadium",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.83
-        },
-        {
-          "name": "Mexico",
-          "probability": 0.03
-        },
-        {
-          "name": "Angola",
-          "probability": 0.03
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.03
-        },
-        {
-          "name": "Switzerland",
-          "probability": 0.03
-        },
-        {
-          "name": "Sierra Leone",
-          "probability": 0.03
-        }
-      ],
       "mu": 47,
       "sigma": 31
     }
   },
   {
     "name": "Surkhon Termez",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Termez",
     "stadium": "Markaziy Stadion",
     "stadium_capacity": 9214,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.89
-        },
-        {
-          "name": "Iceland",
-          "probability": 0.11
-        }
-      ],
       "mu": 61,
       "sigma": 16
     }
   },
   {
     "name": "Neftchi Fergana",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Fergana",
     "stadium": "Istiqlol",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.9
-        },
-        {
-          "name": "San Marino",
-          "probability": 0.03
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.03
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.03
-        }
-      ],
       "mu": 54,
       "sigma": 23
     }
   },
   {
     "name": "Fk Olympik",
-    "country": "Uzbekistan",
+    "country": "UZB",
     "location": "Tashkent",
     "stadium": "Jar Stadium",
     "stadium_capacity": 8460,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Uzbekistan",
-          "probability": 0.85
-        },
-        {
-          "name": "Botswana",
-          "probability": 0.04
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.04
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.04
-        },
-        {
-          "name": "Ireland",
-          "probability": 0.04
-        }
-      ],
       "mu": 76,
       "sigma": 20
     }
   },
   {
     "name": "Estudiantes de M\\u00e9rida",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "M\\u00e9rida",
     "stadium": "Metropolitano de M\\u00e9rida",
     "stadium_capacity": 42200,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.87
-        },
-        {
-          "name": "New Caledonia",
-          "probability": 0.13
-        }
-      ],
       "mu": 78,
       "sigma": 11
     }
   },
   {
     "name": "Deportivo Lara",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Barquisimeto",
     "stadium": "Metropolitano de F\\u00fatbol de Lara",
     "stadium_capacity": 40312,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.78
-        },
-        {
-          "name": "Dominican Republic",
-          "probability": 0.22
-        }
-      ],
       "mu": 66,
       "sigma": 9
     }
   },
   {
     "name": "Llaneros",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Guanare",
     "stadium": "Rafael Calles Pinto",
     "stadium_capacity": 6000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.85
-        },
-        {
-          "name": "Denmark",
-          "probability": 0.03
-        },
-        {
-          "name": "Algeria",
-          "probability": 0.03
-        },
-        {
-          "name": "Japan",
-          "probability": 0.03
-        },
-        {
-          "name": "Wales",
-          "probability": 0.03
-        },
-        {
-          "name": "Philippines",
-          "probability": 0.03
-        }
-      ],
       "mu": 52,
       "sigma": 24
     }
   },
   {
     "name": "Mineros de Guayana",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Puerto Ordaz",
     "stadium": "CTE Cachamay",
     "stadium_capacity": 41300,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.88
-        },
-        {
-          "name": "Laos",
-          "probability": 0.12
-        }
-      ],
       "mu": 58,
       "sigma": 5
     }
   },
   {
     "name": "Trujillanos FC",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Valera",
     "stadium": "Jos\\u00e9 Alberto P\\u00e9rez",
     "stadium_capacity": 25000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.71
-        },
-        {
-          "name": "Poland",
-          "probability": 0.15
-        },
-        {
-          "name": "Cambodia",
-          "probability": 0.15
-        }
-      ],
       "mu": 59,
       "sigma": 21
     }
   },
   {
     "name": "Yaracuyanos FC",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "San Felipe",
     "stadium": "Florentino Oropeza",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.72
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.06
-        },
-        {
-          "name": "Panama",
-          "probability": 0.06
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.06
-        },
-        {
-          "name": "Peru",
-          "probability": 0.06
-        },
-        {
-          "name": "Slovakia",
-          "probability": 0.06
-        }
-      ],
       "mu": 55,
       "sigma": 11
     }
   },
   {
     "name": "Atl\\u00e9tico Venezuela",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Caracas",
     "stadium": "Br\\u00edgido Iriarte",
     "stadium_capacity": 12500,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.81
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.19
-        }
-      ],
       "mu": 68,
       "sigma": 22
     }
   },
   {
     "name": "Portuguesa FC",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Acarigua",
     "stadium": "Jos\\u00e9 Antonio Paez",
     "stadium_capacity": 18000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.76
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.24
-        }
-      ],
       "mu": 75,
       "sigma": 16
     }
   },
   {
     "name": "Tucanes de Amazonas",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "Puerto Ayacucho",
     "stadium": "Antonio Jos\\u00e9 de Sucre",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.87
-        },
-        {
-          "name": "Sweden",
-          "probability": 0.03
-        },
-        {
-          "name": "Estonia",
-          "probability": 0.03
-        },
-        {
-          "name": "Israel",
-          "probability": 0.03
-        },
-        {
-          "name": "Greece",
-          "probability": 0.03
-        },
-        {
-          "name": "Luxembourg",
-          "probability": 0.03
-        }
-      ],
       "mu": 74,
       "sigma": 33
     }
   },
   {
     "name": "Real Frontera SC",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "San Antonio de T\\u00e1chira",
     "stadium": "Estadio Pedro Ch\\u00e1vez",
     "stadium_capacity": 10000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.8
-        },
-        {
-          "name": "Czech Republic",
-          "probability": 0.1
-        },
-        {
-          "name": "Honduras",
-          "probability": 0.1
-        }
-      ],
       "mu": 53,
       "sigma": 34
     }
   },
   {
     "name": "Union Local Andina",
-    "country": "Venezuela",
+    "country": "VEN",
     "location": "M\\u00e9rida",
     "stadium": "Estadio Guillermo Soto Rosa",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Venezuela",
-          "probability": 0.71
-        },
-        {
-          "name": "Antigua and Barbuda",
-          "probability": 0.29
-        }
-      ],
       "mu": 53,
       "sigma": 29
     }
   },
   {
     "name": "Thanh H\\u00f3a FC",
-    "country": "Vietnam",
+    "country": "VIE",
     "location": "Thanh Hoa",
     "stadium": "Thanh H\\u00f3a",
     "stadium_capacity": 14000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Vietnam",
-          "probability": 0.8
-        },
-        {
-          "name": "Mozambique",
-          "probability": 0.04
-        },
-        {
-          "name": "Serbia",
-          "probability": 0.04
-        },
-        {
-          "name": "Colombia",
-          "probability": 0.04
-        },
-        {
-          "name": "Georgia",
-          "probability": 0.04
-        },
-        {
-          "name": "Ethiopia",
-          "probability": 0.04
-        }
-      ],
       "mu": 77,
       "sigma": 12
     }
   },
   {
     "name": "Hoang Anh Gia Lai",
-    "country": "Vietnam",
+    "country": "VIE",
     "location": "Gia Lai",
     "stadium": "Pleiku",
     "stadium_capacity": 12000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Vietnam",
-          "probability": 0.75
-        },
-        {
-          "name": "Tanzania",
-          "probability": 0.25
-        }
-      ],
       "mu": 72,
       "sigma": 30
     }
   },
   {
     "name": "Than Qu\\u1ea3ng Ninh",
-    "country": "Vietnam",
+    "country": "VIE",
     "location": "C\\u1ea9m Ph\\u1ea3",
     "stadium": "C\\u1eeda \\u00d4ng",
     "stadium_capacity": 15000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Vietnam",
-          "probability": 0.79
-        },
-        {
-          "name": "France",
-          "probability": 0.05
-        },
-        {
-          "name": "Gibraltar",
-          "probability": 0.05
-        },
-        {
-          "name": "Costa Rica",
-          "probability": 0.05
-        },
-        {
-          "name": "England",
-          "probability": 0.05
-        }
-      ],
       "mu": 65,
       "sigma": 35
     }
   },
   {
     "name": "Nam D\\u1ecbnh FC",
-    "country": "Vietnam",
+    "country": "VIE",
     "location": "Nam \\u0110\\u1ecbnh",
     "stadium": "Thi\\u00ean Tr\\u01b0\\u1eddng Stadium",
     "stadium_capacity": 20000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Vietnam",
-          "probability": 0.73
-        },
-        {
-          "name": "Nigeria",
-          "probability": 0.27
-        }
-      ],
       "mu": 79,
       "sigma": 9
     }
   },
   {
     "name": "Viettel FC",
-    "country": "Vietnam",
+    "country": "VIE",
     "location": "Hanoi",
     "stadium": "M\\u1ef9 \\u0110\\u00ecnh Stadium",
     "stadium_capacity": 40192,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Vietnam",
-          "probability": 0.89
-        },
-        {
-          "name": "Israel",
-          "probability": 0.11
-        }
-      ],
       "mu": 50,
       "sigma": 35
     }
   },
   {
     "name": "Cardiff City",
-    "country": "Wales",
+    "country": "WAL",
     "location": "Cardiff",
     "stadium": "Cardiff City Stadium",
     "stadium_capacity": 33316,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Wales",
-          "probability": 0.79
-        },
-        {
-          "name": "Montenegro",
-          "probability": 0.04
-        },
-        {
-          "name": "Bahrain",
-          "probability": 0.04
-        },
-        {
-          "name": "Netherlands",
-          "probability": 0.04
-        },
-        {
-          "name": "Bangladesh",
-          "probability": 0.04
-        },
-        {
-          "name": "El Salvador",
-          "probability": 0.04
-        }
-      ],
       "mu": 53,
       "sigma": 25
     }
   },
   {
     "name": "Wrexham",
-    "country": "Wales",
+    "country": "WAL",
     "location": "Wrexham",
     "stadium": "Racecourse Ground",
     "stadium_capacity": 10771,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Wales",
-          "probability": 0.78
-        },
-        {
-          "name": "Austria",
-          "probability": 0.05
-        },
-        {
-          "name": "Togo",
-          "probability": 0.05
-        },
-        {
-          "name": "Macao",
-          "probability": 0.05
-        },
-        {
-          "name": "Zambia",
-          "probability": 0.05
-        }
-      ],
       "mu": 47,
       "sigma": 16
     }
   },
   {
     "name": "Cefn Druids",
-    "country": "Wales",
+    "country": "WAL",
     "location": "Cefn Mawr",
     "stadium": "Plaskynaston Lane",
     "stadium_capacity": 2000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Wales",
-          "probability": 0.71
-        },
-        {
-          "name": "Hungary",
-          "probability": 0.07
-        },
-        {
-          "name": "Angola",
-          "probability": 0.07
-        },
-        {
-          "name": "Argentina",
-          "probability": 0.07
-        },
-        {
-          "name": "Chile",
-          "probability": 0.07
-        }
-      ],
       "mu": 53,
       "sigma": 7
     }
   },
   {
     "name": "Cardiff Metropolitan University",
-    "country": "Wales",
+    "country": "WAL",
     "location": "Cyncoed",
     "stadium": "Cyncoed Campus",
     "stadium_capacity": 1620,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Wales",
-          "probability": 0.82
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.06
-        },
-        {
-          "name": "United Arab Emirates",
-          "probability": 0.06
-        },
-        {
-          "name": "Spain",
-          "probability": 0.06
-        }
-      ],
       "mu": 49,
       "sigma": 11
     }
   },
   {
     "name": "Zesco United",
-    "country": "Zambia",
+    "country": "ZAM",
     "location": "Ndola",
     "stadium": "Levy Mwanawasa stadium",
     "stadium_capacity": 49800,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Zambia",
-          "probability": 0.78
-        },
-        {
-          "name": "Turkey",
-          "probability": 0.04
-        },
-        {
-          "name": "Thailand",
-          "probability": 0.04
-        },
-        {
-          "name": "DR Congo",
-          "probability": 0.04
-        },
-        {
-          "name": "Greece",
-          "probability": 0.04
-        },
-        {
-          "name": "Laos",
-          "probability": 0.04
-        }
-      ],
       "mu": 70,
       "sigma": 29
     }
   },
   {
     "name": "Dynamos FC",
-    "country": "Zimbabwe",
+    "country": "ZIM",
     "location": "Harare",
     "stadium": "Rufaro Stadium",
     "stadium_capacity": 45000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Zimbabwe",
-          "probability": 0.83
-        },
-        {
-          "name": "Liechtenstein",
-          "probability": 0.17
-        }
-      ],
       "mu": 79,
       "sigma": 27
     }
   },
   {
     "name": "CAPS United",
-    "country": "Zimbabwe",
+    "country": "ZIM",
     "location": "Harare",
     "stadium": "National Sports Stadium",
     "stadium_capacity": 60000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Zimbabwe",
-          "probability": 0.74
-        },
-        {
-          "name": "Faroe Islands",
-          "probability": 0.26
-        }
-      ],
       "mu": 55,
       "sigma": 27
     }
   },
   {
     "name": "Chicken Inn FC",
-    "country": "Zimbabwe",
+    "country": "ZIM",
     "location": "Bulawayo",
     "stadium": "Luveve Stadium",
     "stadium_capacity": 8000,
     "squads_def": {
-      "nationalities": [
-        {
-          "name": "Zimbabwe",
-          "probability": 0.84
-        },
-        {
-          "name": "Andorra",
-          "probability": 0.08
-        },
-        {
-          "name": "Bosnia & Herzegovina",
-          "probability": 0.08
-        }
-      ],
       "mu": 64,
       "sigma": 31
     }

--- a/ofm/res/names.json
+++ b/ofm/res/names.json
@@ -1,6 +1,6 @@
 [
   {
-    "region": "Albania",
+    "region": "ALB",
     "male": [
       "Aleks",
       "Alesandro",
@@ -86,7 +86,7 @@
     ]
   },
   {
-    "region": "Argentina",
+    "region": "ARG",
     "male": [
       "Sim\\u00f3n",
       "Paulo",
@@ -1470,7 +1470,7 @@
     ]
   },
   {
-    "region": "Armenia",
+    "region": "ARM",
     "male": [
       "\\u0531\\u0580\\u0574\\u0561\\u0576",
       "\\u0531\\u0580\\u0574\\u0565\\u0576",
@@ -1553,7 +1553,7 @@
     ]
   },
   {
-    "region": "Australia",
+    "region": "AUS",
     "male": [
       "Campbell",
       "Vince",
@@ -2121,7 +2121,7 @@
     ]
   },
   {
-    "region": "Austria",
+    "region": "AUT",
     "male": [
       "Michael",
       "Patrick",
@@ -2287,7 +2287,7 @@
     ]
   },
   {
-    "region": "Azerbaijan",
+    "region": "AZE",
     "male": [
       "Adil",
       "Adnan",
@@ -2530,7 +2530,7 @@
     ]
   },
   {
-    "region": "Bangladesh",
+    "region": "BAN",
     "male": [
       "Apurba",
       "Shafin",
@@ -2614,7 +2614,7 @@
     ]
   },
   {
-    "region": "Belgium",
+    "region": "BEL",
     "male": [
       "Olivier",
       "Thomas",
@@ -3051,7 +3051,7 @@
     ]
   },
   {
-    "region": "Bosnia and Herzegovina",
+    "region": "BIH",
     "male": [
       "Adam",
       "Adin",
@@ -3313,7 +3313,7 @@
     ]
   },
   {
-    "region": "Brazil",
+    "region": "BRA",
     "male": [
       "Ferreira",
       "Lu\\u00eds Fernando",
@@ -4231,7 +4231,7 @@
     ]
   },
   {
-    "region": "Bulgaria",
+    "region": "BUL",
     "male": [
       "Krassimir",
       "Stayko",
@@ -5022,7 +5022,7 @@
     ]
   },
   {
-    "region": "Canada",
+    "region": "CAN",
     "male": [
       "Alex",
       "Alexander",
@@ -5271,7 +5271,7 @@
     ]
   },
   {
-    "region": "China",
+    "region": "CHN",
     "male": [
       "\\u4f1f",
       "\\u521a",
@@ -5679,7 +5679,7 @@
     ]
   },
   {
-    "region": "Colombia",
+    "region": "COL",
     "male": [
       "Adolfo",
       "Alberto",
@@ -5871,7 +5871,7 @@
     ]
   },
   {
-    "region": "Costa Rica",
+    "region": "CRC",
     "male": [
       "Adrian",
       "Carlos Roberto",
@@ -5896,7 +5896,7 @@
     ]
   },
   {
-    "region": "Croatia",
+    "region": "CRO",
     "male": [
       "Ante",
       "Marko",
@@ -5946,7 +5946,7 @@
     ]
   },
   {
-    "region": "Czech",
+    "region": "CZE",
     "male": [
       "Adam",
       "Adri\\u00e1n",
@@ -7580,7 +7580,7 @@
     ]
   },
   {
-    "region": "Czech Republic",
+    "region": "CZE",
     "male": [
       "Jakub",
       "Tom\\u00e1\\u0161",
@@ -7608,7 +7608,7 @@
     ]
   },
   {
-    "region": "Denmark",
+    "region": "DEN",
     "male": [
       "Gunnar",
       "Mogens",
@@ -8389,7 +8389,7 @@
     ]
   },
   {
-    "region": "Egypt",
+    "region": "EGY",
     "male": [
       "\\u0645\\u062d\\u0645\\u062f",
       "\\u0623\\u062d\\u0645\\u062f",
@@ -8443,7 +8443,7 @@
     ]
   },
   {
-    "region": "England",
+    "region": "ENG",
     "male": [
       "Casey",
       "Ted",
@@ -12656,7 +12656,7 @@
     ]
   },
   {
-    "region": "Estonia",
+    "region": "EST",
     "male": [
       "Toomas",
       "Rasmus",
@@ -12838,7 +12838,7 @@
     ]
   },
   {
-    "region": "Finland",
+    "region": "FIN",
     "male": [
       "Juuso",
       "Janne",
@@ -14543,7 +14543,7 @@
     ]
   },
   {
-    "region": "France",
+    "region": "FRA",
     "male": [
       "Abdelhak",
       "Jessy",
@@ -17996,7 +17996,7 @@
     ]
   },
   {
-    "region": "Georgia",
+    "region": "GEO",
     "male": [
       "\\u10d2\\u10d8\\u10dd\\u10e0\\u10d2\\u10d8",
       "\\u10d3\\u10d0\\u10d5\\u10d8\\u10d7",
@@ -18127,7 +18127,7 @@
     ]
   },
   {
-    "region": "Germany",
+    "region": "GER",
     "male": [
       "Gunnar",
       "J\\u00fcrgen",
@@ -20498,7 +20498,7 @@
     ]
   },
   {
-    "region": "Greece",
+    "region": "GRE",
     "male": [
       "\\u0394\\u03b9\\u03cc\\u03bd\\u03c5\\u03c3\\u03bf\\u03c2",
       "Thomas",
@@ -21508,7 +21508,7 @@
     ]
   },
   {
-    "region": "Hungary",
+    "region": "HUN",
     "male": [
       "Art\\u00far",
       "Domokos",
@@ -22441,7 +22441,7 @@
     ]
   },
   {
-    "region": "India",
+    "region": "IND",
     "male": [
       "Aarav",
       "Aaryan",
@@ -22561,7 +22561,7 @@
     ]
   },
   {
-    "region": "Indonesia",
+    "region": "IDN",
     "male": [
       "Adam",
       "Adi",
@@ -22662,7 +22662,7 @@
     ]
   },
   {
-    "region": "Iran",
+    "region": "IRN",
     "male": [
       "\\u0627\\u0645\\u06cc\\u0631 \\u0639\\u0644\\u06cc",
       "\\u067e\\u0631\\u0647\\u0627\\u0645",
@@ -22871,7 +22871,7 @@
     ]
   },
   {
-    "region": "Ireland",
+    "region": "IRL",
     "male": [
       "Jack",
       "James",
@@ -22920,7 +22920,7 @@
     ]
   },
   {
-    "region": "Israel",
+    "region": "ISR",
     "male": [
       "Almog",
       "Liran",
@@ -23429,7 +23429,7 @@
     ]
   },
   {
-    "region": "Italy",
+    "region": "ITA",
     "male": [
       "Enea",
       "Costanzo",
@@ -27277,7 +27277,7 @@
     ]
   },
   {
-    "region": "Japan",
+    "region": "JPN",
     "male": [
       "\\u7fd4\\u5e73",
       "Masashi",
@@ -27728,7 +27728,7 @@
     ]
   },
   {
-    "region": "Korea",
+    "region": "KOR",
     "male": [
       "\\uac74\\uc6b0",
       "\\ub3c4\\uc724",
@@ -27916,7 +27916,7 @@
     ]
   },
   {
-    "region": "Kyrgyz Republic",
+    "region": "KGZ",
     "male": [
       "Abai",
       "Abdurazak",
@@ -28280,7 +28280,7 @@
     ]
   },
   {
-    "region": "Latvia",
+    "region": "LVA",
     "male": [
       "\\u0100dolfs",
       "Aivars",
@@ -28621,7 +28621,7 @@
     ]
   },
   {
-    "region": "Mexico",
+    "region": "MEX",
     "male": [
       "Jos\\u00e9 Luis",
       "Juan",
@@ -29130,7 +29130,7 @@
     ]
   },
   {
-    "region": "Morocco",
+    "region": "MAR",
     "male": [
       "Abdel",
       "Abderrahim",
@@ -29215,7 +29215,7 @@
     ]
   },
   {
-    "region": "Nepal",
+    "region": "NEP",
     "male": [
       "Aakash",
       "Abhinash",
@@ -29694,7 +29694,7 @@
     ]
   },
   {
-    "region": "Netherlands",
+    "region": "NED",
     "male": [
       "J\\u00fcrgen",
       "Thomas",
@@ -31310,7 +31310,7 @@
     ]
   },
   {
-    "region": "New Zealand",
+    "region": "NZL",
     "male": [
       "Aaron",
       "Adam",
@@ -31711,7 +31711,7 @@
     ]
   },
   {
-    "region": "Nigeria",
+    "region": "NGA",
     "male": [
       "Aanu",
       "Abey",
@@ -31820,7 +31820,7 @@
     ]
   },
   {
-    "region": "Norway",
+    "region": "NOR",
     "male": [
       "Gunnar",
       "Torbj\\u00f8rn",
@@ -32816,7 +32816,7 @@
     ]
   },
   {
-    "region": "Pakistan",
+    "region": "PAK",
     "male": [
       "Abdullah",
       "Adeel",
@@ -32965,7 +32965,7 @@
     ]
   },
   {
-    "region": "Peru",
+    "region": "PER",
     "male": [
       "Abel",
       "Adan",
@@ -33230,7 +33230,7 @@
     ]
   },
   {
-    "region": "Poland",
+    "region": "POL",
     "male": [
       "Mi\\u0142osz",
       "Onufry",
@@ -35098,7 +35098,7 @@
     ]
   },
   {
-    "region": "Portugal",
+    "region": "POR",
     "male": [
       "Paulo",
       "Alfredo",
@@ -35493,7 +35493,7 @@
     ]
   },
   {
-    "region": "Romania",
+    "region": "ROU",
     "male": [
       "Laz\\u0103r",
       "Petronel",
@@ -37184,7 +37184,7 @@
     ]
   },
   {
-    "region": "Russia",
+    "region": "RUS",
     "male": [
       "Almaz",
       "Kiril",
@@ -40011,7 +40011,7 @@
     ]
   },
   {
-    "region": "Saudi Arabia",
+    "region": "KSA",
     "male": [
       "\\u0623\\u062d\\u0645\\u062f",
       "\\u0623\\u0645\\u064a\\u0646",
@@ -40164,7 +40164,7 @@
     ]
   },
   {
-    "region": "Scotland",
+    "region": "SCO",
     "male": [
       "Aaron",
       "Adam",
@@ -41616,7 +41616,7 @@
     ]
   },
   {
-    "region": "Serbia",
+    "region": "SRB",
     "male": [
       "Adem",
       "Admir",
@@ -42388,7 +42388,7 @@
     ]
   },
   {
-    "region": "Slovakia",
+    "region": "SVK",
     "male": [
       "Adam",
       "Adolf",
@@ -43085,7 +43085,7 @@
     ]
   },
   {
-    "region": "Slovenia",
+    "region": "SVN",
     "male": [
       "Vinko",
       "Vojko",
@@ -43582,7 +43582,7 @@
     ]
   },
   {
-    "region": "Spain",
+    "region": "ESP",
     "male": [
       "Sim\\u00f3n",
       "Paulo",
@@ -44919,7 +44919,7 @@
     ]
   },
   {
-    "region": "Sweden",
+    "region": "SWE",
     "male": [
       "Gunnar",
       "Janne",
@@ -45743,7 +45743,7 @@
     ]
   },
   {
-    "region": "Switzerland",
+    "region": "SUI",
     "male": [
       "Hans",
       "Peter",
@@ -45813,7 +45813,7 @@
     ]
   },
   {
-    "region": "Tunisia",
+    "region": "TUN",
     "male": [
       "\\u0639\\u0628\\u062f \\u0627\\u0644\\u0646\\u0648\\u0631",
       "\\u062a\\u0648\\u0647\\u0627\\u0645\\u064a",
@@ -45927,7 +45927,7 @@
     ]
   },
   {
-    "region": "Turkey",
+    "region": "TUR",
     "male": [
       "G\\u00fcven\\u0131\\u015f\\u0131k",
       "R\\u0131za",
@@ -47120,7 +47120,7 @@
     ]
   },
   {
-    "region": "Ukraine",
+    "region": "UKR",
     "male": [
       "Kostantyn",
       "\\u0412\\u0456\\u043a\\u0442\\u043e\\u0440",
@@ -47852,7 +47852,7 @@
     ]
   },
   {
-    "region": "United States",
+    "region": "USA",
     "male": [
       "Aaron",
       "Adam",
@@ -48361,7 +48361,7 @@
     ]
   },
   {
-    "region": "United states",
+    "region": "USA",
     "male": [
       "Jimmy",
       "Brian",
@@ -49180,7 +49180,7 @@
     ]
   },
   {
-    "region": "Vietnam",
+    "region": "VIE",
     "male": [
       "An",
       "Anh",

--- a/ofm/tests/test_settings.py
+++ b/ofm/tests/test_settings.py
@@ -32,6 +32,8 @@ def test_get_settings(settings, tmp_path):
         "db": os.path.join(tmp_path, "res", "db"),
         "save": os.path.join(tmp_path, "save"),
         "clubs_def": os.path.join(tmp_path, "res", "clubs_def.json"),
+        "fifa_codes": os.path.join(tmp_path, "res", "fifa-country-codes.json"),
+        "fifa_conf": os.path.join(tmp_path, "res", "fifa-confederations.json"),
         "squads": os.path.join(tmp_path, "res", "db", "squads.json"),
         "players": os.path.join(tmp_path, "res", "db", "players.json"),
         "clubs": os.path.join(tmp_path, "res", "db", "clubs.json"),

--- a/ofm/tests/test_teams.py
+++ b/ofm/tests/test_teams.py
@@ -26,23 +26,9 @@ def get_squads_def() -> list[dict]:
             "name": "Munchen",
             "stadium_name": "Munchen National Stadium",
             "stadium_capacity": 40100,
-            "country": "Germany",
+            "country": "GER",
             "location": "Munich",
             "squad_def": {
-                "nationalities": [
-                    {
-                        "name": "Germany",
-                        "probability": 0.90,
-                    },
-                    {
-                        "name": "France",
-                        "probability": 0.05,
-                    },
-                    {
-                        "name": "Spain",
-                        "probability": 0.05,
-                    },
-                ],
                 "mu": 80,
                 "sigma": 20,
             },
@@ -51,14 +37,9 @@ def get_squads_def() -> list[dict]:
             "name": "Barcelona",
             "stadium_name": "Barcelona National Stadium",
             "stadium_capacity": 50000,
-            "country": "Spain",
+            "country": "ESP",
             "location": "Barcelona",
             "squad_def": {
-                "nationalities": [
-                    {"name": "Spain", "probability": 0.90},
-                    {"name": "Germany", "probability": 0.05},
-                    {"name": "France", "probability": 0.05},
-                ],
                 "mu": 80,
                 "sigma": 20,
             },
@@ -71,7 +52,7 @@ def get_club_mock_file() -> list[dict]:
         {
             "id": 1,
             "name": "Munchen",
-            "country": "Germany",
+            "country": "GER",
             "location": "Munich",
             "squad": [],
             "stadium_name": "Munchen National Stadium",
@@ -80,7 +61,7 @@ def get_club_mock_file() -> list[dict]:
         {
             "id": 2,
             "name": "Barcelona",
-            "country": "Spain",
+            "country": "ESP",
             "location": "Barcelona",
             "squad": [],
             "stadium_name": "Barcelona National Stadium",


### PR DESCRIPTION
PR:
- replaces `"region": "Albania"` with `"region": "ALB"` from **clubs_def.json**;
- replaces `"country": "Albania"` with `"country": "ALB"` from **clubs_def.json**;
- removed `"nationalities"` from **clubs_def.json**;

you were right, clubs_def was too big, and without nationalities it weights half! What about the nationalities? Keep reading.

- added **extract_confederation** in **generators.py**
let's say we have a Spanish club, whatever you want to, we can extract UEFA (since it's Spanish) and then it creates a list with all the countries excluded Spain. Why? Random nationalities.

- updated **_get_nationalities**
```
        # native
        native: float = 0.85
        nationalities.append(country)
        probabilities.append(native)
        # foreigner
        foreigner: float = 1 - native
        coeff = int(foreigner / 0.05)
        mini_list = random.sample(countries, coeff)
```
`native: float = 0.85` -> .85 just for example, we can generate it randomly, or in the JSON, or for confederation (UEFA, native .75, etc).
`foreigner: float = 1 - native` automatically generated from native (eg .15)
`coeff = int(foreigner / 0.05)` .05 because corresponds to 1 player (1/22 = .045)

_nb. if we do 25 players instead of 22, it would be exactly .04; we need just 2 MF and 1 FW more_

it would give at least 3 players random nationality, the majority native
it's not ideal, but at least it allows to reduce the amount of data inside the JSONs
the parameter UEFA is here:
```
            country_conf, countries_list = self.extract_confederation(
                club["country"], self.fifa_confederations
            )
```
country_conf is UEFA (eg Spanish club), but I don't know where to put it.